### PR TITLE
Fix typo in build-libc dependencies

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -113,7 +113,7 @@ build-binutils: stamps/build-binutils-@default_target@
 build-gdb: stamps/build-gdb-@default_target@
 build-gcc%: stamps/build-gcc-@default_target@-stage%
 ifeq (@default_target@,linux)
-build-libc: $(patsubst %,stamps/build-glibc-linux-%,$(MULTLIB_NAMES))
+build-libc: $(addprefix stamps/build-glibc-linux-,$(GLIBC_MULTILIB_NAMES))
 else
 build-libc: stamps/build-newlib stamps/build-newlib-nano \
 	stamps/merge-newlib-nano


### PR DESCRIPTION
The variable MULTLIB_NAMES does not exist but is used when
generating the dependencies for the target build-libc for glibc.
Even when adding the missing 'I' (for MULTILIB_NAMES) there is
still no variable with this name.

So the whole dependency generation is useless, becauese it was not
needed so far. Looking into detail why it is so, we can find the
answer in the dependency list of the target 'stamps/build-gcc-linux-stage2'.

Let's fix this by setting the dependencies for build-libc right.
The dependencies for 'stamps/build-gcc-linux-stage2' stay as they are
not wrong.

Fixes: 3456b66f69 ("Add a "make report" phony target")
Signed-off-by: Christoph Muellner <cmuellner@linux.com>