### PR TITLE
gcc: add source SHA1 which shows up in -v

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -243,6 +243,12 @@ else
 GLIBC_SRC_GIT :=
 endif
 
+ifneq ("$(wildcard $(GCC_SRCDIR)/.git)","")
+GCCPKGVER := g$(shell git -C $(GCC_SRCDIR) describe --always --dirty --exclude '*')
+else
+GCCPKGVER :=
+endif
+
 $(srcdir)/%/.git:
 	cd $(srcdir) && \
 	flock `git rev-parse --git-dir`/config git submodule init $(dir $@) && \
@@ -396,6 +402,7 @@ stamps/build-gcc-linux-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) $(addprefix stamps/b
 		$(CONFIGURE_HOST) \
 		--prefix=$(INSTALL_DIR) \
 		--with-sysroot=$(SYSROOT) \
+		--with-pkgversion="$(GCCPKGVER)" \
 		@with_system_zlib@ \
 		--enable-shared \
 		--enable-tls \
@@ -621,6 +628,7 @@ stamps/build-gcc-newlib-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-newlib
 		--disable-shared \
 		--disable-threads \
 		--enable-languages=c,c++ \
+		--with-pkgversion="$(GCCPKGVER)" \
 		@with_system_zlib@ \
 		--enable-tls \
 		--with-newlib \


### PR DESCRIPTION
This helps identify the exact sources used for building the compiler.

| riscv64-unknown-linux-gnu-gcc -v
|
| Before: gcc version 11.1.0 (GCC)
| After : gcc version 11.1.0 (g480822473a4a)

Signed-off-by: Vineet Gupta <vineetg@rivosinc.com>