### PR TITLE
Set CXX to a nonexistant compiler when building glibc

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -327,7 +327,7 @@ endif
 	mkdir $(notdir $@)
 	cd $(notdir $@) && \
 		CC="$(GLIBC_CC_FOR_TARGET) $($@_CFLAGS)" \
-		CXX="$(GLIBC_CXX_FOR_TARGET) $($@_CFLAGS)" \
+		CXX="this-is-not-the-compiler-youre-looking-for" \
 		CFLAGS="$(CFLAGS_FOR_TARGET) -g -O2 $($@_CFLAGS)" \
 		CXXFLAGS="$(CXXFLAGS_FOR_TARGET) -g -O2 $($@_CFLAGS)" \
 		ASFLAGS="$(ASFLAGS_FOR_TARGET) $($@_CFLAGS)" \


### PR DESCRIPTION
We set CXX=riscv64-unknown-linux-gnu-g++ (or something like that) when
building glibc, but don't actually build a C++ compiler during stage 1.
Under normal conditions this shouldn't cause any issues: that's either a
working compiler (from PATH) or doesn't exist, in which case glibc's
build scripts do the right thing and turn off C++.  Unfortunately I'm in
the pathological situation of having a slightly-incompatble g++ in PATH,
which glibc then attempts to use only to throw an error when linking
(glibc isn't testing that much of the C++ toolchain, see
<https://sourceware.org/bugzilla/show_bug.cgi?id=24183>).

This simply sets CXX to something that's unlikely to exist during the
glibc build, so the build scripts don't get confused.  I tried setting
this to false, but everything was italic.

Signed-off-by: Palmer Dabbelt <palmer@rivosinc.com>