### PR TITLE
Change Arch requirement mpc to libmpc as reported by @erdnaxe

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ On Fedora/CentOS/RHEL OS, executing the following command should suffice:
     
 On Arch Linux, executing the following command should suffice:
 
-    $ pacman -Syyu autoconf automake curl python3 mpc mpfr gmp gawk base-devel bison flex texinfo gperf libtool patchutils bc zlib expat
+    $ sudo pacman -Syyu autoconf automake curl python3 libmpc mpfr gmp gawk base-devel bison flex texinfo gperf libtool patchutils bc zlib expat
 
 Also available for Arch users on the AUR: [https://aur.archlinux.org/packages/riscv-gnu-toolchain/](https://aur.archlinux.org/packages/riscv-gnu-toolchain/)
 


### PR DESCRIPTION
Just updating previous PR as `mpc` is a music player, however `libmpc` is the correct required package.