### PR TITLE
Additional packages needed for Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Several standard packages are needed to build the toolchain.
 
 On Ubuntu, executing the following command should suffice:
 
-    $ sudo apt-get install autoconf automake autotools-dev curl python3 libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev
+    $ sudo apt-get install autoconf automake autotools-dev curl python3 python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev swig
 
 On Fedora/CentOS/RHEL OS, executing the following command should suffice:
 


### PR DESCRIPTION
For Ubuntu 20.04, I didn't have `python3-pip` or `swig` installed by default.