### PR TITLE
Allow source-override for QEMU

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -9,6 +9,7 @@ GLIBC_SRCDIR := @with_glibc_src@
 MUSL_SRCDIR := @with_musl_src@
 LINUX_HEADERS_SRCDIR := @with_linux_headers_src@
 GDB_SRCDIR := @with_gdb_src@
+QEMU_SRCDIR := @with_qemu_src@
 
 SIM:=qemu
 
@@ -241,6 +242,12 @@ ifeq ($(findstring $(srcdir),$(GLIBC_SRCDIR)),$(srcdir))
 GLIBC_SRC_GIT := $(GLIBC_SRCDIR)/.git
 else
 GLIBC_SRC_GIT :=
+endif
+
+ifeq ($(findstring $(srcdir),$(QEMU_SRCDIR)),$(srcdir))
+QEMU_SRC_GIT := $(QEMU_SRCDIR)/.git
+else
+QEMU_SRC_GIT :=
 endif
 
 ifneq ("$(wildcard $(GCC_SRCDIR)/.git)","")
@@ -820,7 +827,7 @@ stamps/build-pk64: pk-src stamps/build-gcc-newlib-stage2
 	mkdir -p $(dir $@)
 	date > $@
 
-stamps/build-qemu: $(srcdir)/qemu $(srcdir)/qemu/.git
+stamps/build-qemu: $(QEMU_SRCDIR) $(QEMU_SRC_GIT)
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \

--- a/README.md
+++ b/README.md
@@ -240,4 +240,5 @@ Here is the list of configure option for specify source tree:
     --with-musl-src
     --with-gdb-src
     --with-linux-headers-src
+    --with-qemu-src
 

--- a/configure
+++ b/configure
@@ -585,6 +585,7 @@ PACKAGE_URL=''
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
 with_linux_headers_src
+with_qemu_src
 with_gdb_src
 with_musl_src
 with_glibc_src
@@ -686,6 +687,7 @@ with_newlib_src
 with_glibc_src
 with_musl_src
 with_gdb_src
+with_qemu_src
 with_linux_headers_src
 '
       ac_precious_vars='build_alias
@@ -1352,6 +1354,7 @@ Optional Packages:
   --with-glibc-src        Set glibc source path, use builtin source by default
   --with-musl-src         Set musl source path, use builtin source by default
   --with-gdb-src          Set gdb source path, use builtin source by default
+  --with-qemu-src         Set qemu source path, use builtin source by default
   --with-linux-headers-src
                           Set linux-headers source path, use builtin source by
                           default
@@ -3613,6 +3616,25 @@ fi
 
 else
   with_gdb_src="\$(srcdir)/riscv-gdb"
+
+fi
+
+	}
+{
+
+# Check whether --with-qemu-src was given.
+if test "${with_qemu_src+set}" = set; then :
+  withval=$with_qemu_src;
+else
+  with_qemu_src=default
+
+fi
+
+	  if test "x$with_qemu_src" != xdefault; then :
+  with_qemu_src=$with_qemu_src
+
+else
+  with_qemu_src="\$(srcdir)/riscv-qemu"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -221,6 +221,7 @@ AX_ARG_WITH_SRC(newlib)
 AX_ARG_WITH_SRC(glibc)
 AX_ARG_WITH_SRC(musl)
 AX_ARG_WITH_SRC(gdb)
+AX_ARG_WITH_SRC(qemu)
 
 AC_ARG_WITH(linux-headers-src,
 	[AC_HELP_STRING([--with-linux-headers-src],


### PR DESCRIPTION
This patch introduces a configure-time source-dir override for QEMU
similar to the existing overrides for the other toolchain sources.