### PR TITLE
Fix incorrect qemu path in configure script

### DIFF
--- a/configure
+++ b/configure
@@ -3634,7 +3634,7 @@ fi
   with_qemu_src=$with_qemu_src
 
 else
-  with_qemu_src="\$(srcdir)/riscv-qemu"
+  with_qemu_src="\$(srcdir)/qemu"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -211,17 +211,17 @@ AC_DEFUN([AX_ARG_WITH_SRC],
 		)
 	  AS_IF([test "x$opt_name" != xdefault],
 		[AC_SUBST(opt_name,$opt_name)],
-		[AC_SUBST(opt_name,"\$(srcdir)/riscv-$1")])
+		[AC_SUBST(opt_name,"\$(srcdir)/$2")])
 	  m4_popdef([opt_name])
 	}])
 
-AX_ARG_WITH_SRC(gcc)
-AX_ARG_WITH_SRC(binutils)
-AX_ARG_WITH_SRC(newlib)
-AX_ARG_WITH_SRC(glibc)
-AX_ARG_WITH_SRC(musl)
-AX_ARG_WITH_SRC(gdb)
-AX_ARG_WITH_SRC(qemu)
+AX_ARG_WITH_SRC(gcc, riscv-gcc)
+AX_ARG_WITH_SRC(binutils, riscv-binutils)
+AX_ARG_WITH_SRC(newlib, riscv-newlib)
+AX_ARG_WITH_SRC(glibc, riscv-glibc)
+AX_ARG_WITH_SRC(musl, riscv-musl)
+AX_ARG_WITH_SRC(gdb, riscv-gdb)
+AX_ARG_WITH_SRC(qemu, qemu)
 
 AC_ARG_WITH(linux-headers-src,
 	[AC_HELP_STRING([--with-linux-headers-src],


### PR DESCRIPTION
This patch fixes a build failure introduced by #1023 / b83ee52.
This commit allowed to configure the toolchain with the QEMU sources outside of the toolchain tree. Unfortunately, the default directory if no QEMU root is configured manually is incorrect, as it refers to `riscv-qemu` instead of `qemu`. This causes the `build-qemu` target in the generated Makefile to fail.

There are two possible solutions:
1. Rename the `qemu` submodule to `riscv-qemu` (i.e., adapt the directory structure to the script), or
2. Change the path in the [configure  script](https://github.com/riscv-collab/riscv-gnu-toolchain/blob/217e7f3debe424d61374d31e33a091a630535937/configure#L3637) (i.e., adapt the script to the directory structure).

I opted for the latter solution, since it seemed to be an easier and quicker fix and the `riscv-` prefix in my understanding implies modifications to the upstream version. To the best of my knowledge, QEMU is just taken from the upstream repository and there are no modifications that would justify such a prefix according to my understanding.

Thanks for your work on the toolchain and for considering this pull request!