### PR TITLE
Fix the default QEMU srcdir

### DIFF
--- a/configure
+++ b/configure
@@ -3634,7 +3634,7 @@ fi
   with_qemu_src=$with_qemu_src
 
 else
-  with_qemu_src="\$(srcdir)/riscv-qemu"
+  with_qemu_src="\$(srcdir)/qemu"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -211,17 +211,17 @@ AC_DEFUN([AX_ARG_WITH_SRC],
 		)
 	  AS_IF([test "x$opt_name" != xdefault],
 		[AC_SUBST(opt_name,$opt_name)],
-		[AC_SUBST(opt_name,"\$(srcdir)/riscv-$1")])
+		[AC_SUBST(opt_name,"\$(srcdir)/$2")])
 	  m4_popdef([opt_name])
 	}])
 
-AX_ARG_WITH_SRC(gcc)
-AX_ARG_WITH_SRC(binutils)
-AX_ARG_WITH_SRC(newlib)
-AX_ARG_WITH_SRC(glibc)
-AX_ARG_WITH_SRC(musl)
-AX_ARG_WITH_SRC(gdb)
-AX_ARG_WITH_SRC(qemu)
+AX_ARG_WITH_SRC(gcc, riscv-gcc)
+AX_ARG_WITH_SRC(binutils, riscv-binutils)
+AX_ARG_WITH_SRC(newlib, riscv-newlib)
+AX_ARG_WITH_SRC(glibc, riscv-glibc)
+AX_ARG_WITH_SRC(musl, riscv-musl)
+AX_ARG_WITH_SRC(gdb, riscv-gdb)
+AX_ARG_WITH_SRC(qemu, qemu)
 
 AC_ARG_WITH(linux-headers-src,
 	[AC_HELP_STRING([--with-linux-headers-src],


### PR DESCRIPTION
As of b83ee52 ("Allow source-override for QEMU"), builds that don't include an explicit --with-qemu-src can't run the tests as the point to a QEMU source directory that doesn't actually exist.  This fixes the build scripts to default to the QEMU source directory we're cloning by default.

I've only minimally tested this, but as the configure diff is so small and what's there was obviously broken it seems like an easy one.  I also noticed there's a default for MUSL that points to a directory that doesn't exist, that's probably not sane but I don't build MUSL so I don't know for sure.