### PR TITLE
Update binutils to version 2.38

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "riscv-binutils"]
 	path = riscv-binutils
 	url = https://github.com/riscv-collab/riscv-binutils-gdb.git
-	branch = riscv-binutils-2.36.1
+	branch = riscv-binutils-2.38
 [submodule "riscv-gcc"]
 	path = riscv-gcc
 	url = https://github.com/riscv-collab/riscv-gcc.git


### PR DESCRIPTION
This will allow us to use newly implemented RISC-V crypto and vector instruction sets in ld linker.