### PR TITLE
Bump binutils to 2.38 release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "riscv-binutils"]
 	path = riscv-binutils
 	url = https://github.com/riscv-collab/riscv-binutils-gdb.git
-	branch = riscv-binutils-2.36.1
+	branch = riscv-binutils-2.38
 [submodule "riscv-gcc"]
 	path = riscv-gcc
 	url = https://github.com/riscv-collab/riscv-gcc.git


### PR DESCRIPTION
I do have a question though:
Does the .gitmodule entry for binutils need to be updated (it wasn't when last bumped to 2.37)
