### PR TITLE
Add --with-isa-spec option to configure

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -33,6 +33,7 @@ endif
 WITH_ARCH ?= @WITH_ARCH@
 WITH_ABI ?= @WITH_ABI@
 WITH_TUNE ?= @WITH_TUNE@
+WITH_ISA_SPEC ?= @WITH_ISA_SPEC@
 SYSROOT := $(INSTALL_DIR)/sysroot
 
 SHELL := /bin/sh
@@ -282,7 +283,8 @@ stamps/build-binutils-linux: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/check
 		--disable-gdb \
 		--disable-sim \
 		--disable-libdecnumber \
-		--disable-readline
+		--disable-readline \
+		$(WITH_ISA_SPEC)
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -389,6 +391,7 @@ stamps/build-gcc-linux-stage1: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-binutil
 		$(WITH_ABI) \
 		$(WITH_ARCH) \
 		$(WITH_TUNE) \
+		$(WITH_ISA_SPEC) \
 		CFLAGS_FOR_TARGET="-O2 $(CFLAGS_FOR_TARGET)" \
 		CXXFLAGS_FOR_TARGET="-O2 $(CXXFLAGS_FOR_TARGET)"
 	$(MAKE) -C $(notdir $@) inhibit-libc=true all-gcc
@@ -426,6 +429,7 @@ stamps/build-gcc-linux-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) $(addprefix stamps/b
 		$(WITH_ABI) \
 		$(WITH_ARCH) \
 		$(WITH_TUNE) \
+		$(WITH_ISA_SPEC) \
 		CFLAGS_FOR_TARGET="-O2 $(CFLAGS_FOR_TARGET)" \
 		CXXFLAGS_FOR_TARGET="-O2 $(CXXFLAGS_FOR_TARGET)"
 	$(MAKE) -C $(notdir $@)
@@ -449,7 +453,8 @@ stamps/build-binutils-linux-native: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamp
 		--disable-gdb \
 		--disable-sim \
 		--disable-libdecnumber \
-		--disable-readline
+		--disable-readline \
+		$(WITH_ISA_SPEC)
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -477,7 +482,8 @@ stamps/build-gcc-linux-native: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-gcc-lin
 		$(MULTILIB_FLAGS) \
 		$(WITH_ABI) \
 		$(WITH_ARCH) \
-		$(WITH_TUNE)
+		$(WITH_TUNE) \
+		$(WITH_ISA_SPEC) \
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	cp -a $(INSTALL_DIR)/$(LINUX_TUPLE)/lib* $(SYSROOT)
@@ -501,7 +507,8 @@ stamps/build-binutils-newlib: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/chec
 		--disable-gdb \
 		--disable-sim \
 		--disable-libdecnumber \
-		--disable-readline
+		--disable-readline \
+		$(WITH_ISA_SPEC)
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -554,6 +561,7 @@ stamps/build-gcc-newlib-stage1: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-binuti
 		$(WITH_ABI) \
 		$(WITH_ARCH) \
 		$(WITH_TUNE) \
+		$(WITH_ISA_SPEC) \
 		CFLAGS_FOR_TARGET="-Os $(CFLAGS_FOR_TARGET)" \
 		CXXFLAGS_FOR_TARGET="-Os $(CXXFLAGS_FOR_TARGET)"
 	$(MAKE) -C $(notdir $@) all-gcc
@@ -653,6 +661,7 @@ stamps/build-gcc-newlib-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-newlib
 		$(WITH_ABI) \
 		$(WITH_ARCH) \
 		$(WITH_TUNE) \
+		$(WITH_ISA_SPEC) \
 		CFLAGS_FOR_TARGET="-Os $(CFLAGS_FOR_TARGET)" \
 		CXXFLAGS_FOR_TARGET="-Os $(CXXFLAGS_FOR_TARGET)"
 	$(MAKE) -C $(notdir $@)
@@ -680,7 +689,8 @@ stamps/build-binutils-musl: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/check-
 		--disable-gdb \
 		--disable-sim \
 		--disable-libdecnumber \
-		--disable-readline
+		--disable-readline \
+		$(WITH_ISA_SPEC)
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -713,6 +723,7 @@ stamps/build-gcc-musl-stage1: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-binutils
 		$(WITH_ABI) \
 		$(WITH_ARCH) \
 		$(WITH_TUNE) \
+		$(WITH_ISA_SPEC) \
 		CFLAGS_FOR_TARGET="-O2 $(CFLAGS_FOR_TARGET)" \
 		CXXFLAGS_FOR_TARGET="-O2 $(CXXFLAGS_FOR_TARGET)"
 	$(MAKE) -C $(notdir $@) inhibit-libc=true all-gcc
@@ -780,6 +791,7 @@ stamps/build-gcc-musl-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-musl-lin
 		$(WITH_ABI) \
 		$(WITH_ARCH) \
 		$(WITH_TUNE) \
+		$(WITH_ISA_SPEC) \
 		CFLAGS_FOR_TARGET="-O2 $(CFLAGS_FOR_TARGET)" \
 		CXXFLAGS_FOR_TARGET="-O2 $(CXXFLAGS_FOR_TARGET)"
 	$(MAKE) -C $(notdir $@)

--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ devtoolset-7 works.
 There are a number of additional options that may be passed to
 configure.  See './configure --help' for more details.
 
+#### Set default ISA spec version
+
+`--with-isa-spec=` can specify the default version of the RISC-V Unprivileged
+(formerly User-Level) ISA specification.
+
+Possible options are: `2.2`, `20190608` and `20191213`.
+
+The default version is `2.2`.
+
+More details about this option you can refer this post [RISC-V GNU toolchain bumping default ISA spec to 20191213](https://groups.google.com/a/groups.riscv.org/g/sw-dev/c/aE1ZeHHCYf4).
+
 #### Build with customized multi-lib configure.
 
 `--with-multilib-generator=` can specify what multilibs to build.  The argument

--- a/configure
+++ b/configure
@@ -604,6 +604,7 @@ newlib_multilib_names
 glibc_multilib_names
 multilib_flags
 multilib_gen
+WITH_ISA_SPEC
 WITH_TUNE
 WITH_ABI
 WITH_ARCH
@@ -671,6 +672,7 @@ enable_linux
 with_arch
 with_abi
 with_tune
+with_isa_spec
 enable_multilib
 with_multilib_generator
 enable_gcc_checking
@@ -1333,6 +1335,8 @@ Optional Packages:
   --with-arch=rv64imafdc  Sets the base RISC-V ISA, defaults to rv64imafdc
   --with-abi=lp64d        Sets the base RISC-V ABI, defaults to lp64d
   --with-tune=rocket      Set the base RISC-V CPU, defaults to rocket
+  --with-isa-spec=2.2     Set the default ISA spec version, default to 2.2,
+                          available options: 2.2, 20190608, 20191213
   --with-multilib-generator
                           Multi-libs configuration string, only supported for
                           bare-metal/elf toolchaih, this option implied
@@ -3301,6 +3305,16 @@ else
 fi
 
 
+
+# Check whether --with-isa-spec was given.
+if test "${with_isa_spec+set}" = set; then :
+  withval=$with_isa_spec;
+else
+  with_isa_spec=2.2
+
+fi
+
+
 if test "x$with_abi" = xdefault; then :
   case $with_arch in #(
   *rv64g* | *rv64*d*) :
@@ -3328,6 +3342,8 @@ WITH_ARCH=--with-arch=$with_arch
 WITH_ABI=--with-abi=$with_abi
 
 WITH_TUNE=--with-tune=$with_tune
+
+WITH_ISA_SPEC=--with-isa-spec=$with_isa_spec
 
 
 # Check whether --enable-multilib was given.

--- a/configure.ac
+++ b/configure.ac
@@ -71,6 +71,13 @@ AC_ARG_WITH(tune,
 	[with_tune=rocket]
 	)
 
+AC_ARG_WITH(isa-spec,
+	[AS_HELP_STRING([--with-isa-spec=2.2],
+		[Set the default ISA spec version, default to 2.2, available options: 2.2, 20190608, 20191213])],
+	[],
+	[with_isa_spec=2.2]
+	)
+
 AS_IF([test "x$with_abi" = xdefault],
 	[AS_CASE([$with_arch],
 		[*rv64g* | *rv64*d*], [with_abi=lp64d],
@@ -86,6 +93,7 @@ AS_IF([test "x$with_abi" = xdefault],
 AC_SUBST(WITH_ARCH, --with-arch=$with_arch)
 AC_SUBST(WITH_ABI, --with-abi=$with_abi)
 AC_SUBST(WITH_TUNE, --with-tune=$with_tune)
+AC_SUBST(WITH_ISA_SPEC, --with-isa-spec=$with_isa_spec)
 
 AC_ARG_ENABLE(multilib,
 	[AS_HELP_STRING([--enable-multilib],


### PR DESCRIPTION
Add `--with-isa-spec` option to configure script.

Set the default version to 2.2 for now, and once we bump to GCC 12 we
will bump that to 20191213.