### PR TITLE
Add an "--enable-libsanitizer" configure-time argument

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -35,6 +35,7 @@ WITH_ABI ?= @WITH_ABI@
 WITH_TUNE ?= @WITH_TUNE@
 WITH_ISA_SPEC ?= @WITH_ISA_SPEC@
 SYSROOT := $(INSTALL_DIR)/sysroot
+ENABLE_LIBSANITIZER ?= @enable_libsanitizer@
 
 SHELL := /bin/sh
 AWK := @GAWK@
@@ -410,9 +411,6 @@ stamps/build-gcc-linux-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) $(addprefix stamps/b
                                stamps/build-glibc-linux-headers
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
-	# libsanitizer not supported rv32,
-	# but it will break the rv64 multi-lib build, so we disable that
-	# temporally untill rv32 supported.
 	cd $(notdir $@) && $</configure \
 		--target=$(LINUX_TUPLE) \
 		$(CONFIGURE_HOST) \
@@ -426,7 +424,7 @@ stamps/build-gcc-linux-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) $(addprefix stamps/b
 		--disable-libmudflap \
 		--disable-libssp \
 		--disable-libquadmath \
-		--disable-libsanitizer \
+		$(ENABLE_LIBSANITIZER) \
 		--disable-nls \
 		--disable-bootstrap \
 		--src=$(gccsrcdir) \

--- a/configure
+++ b/configure
@@ -585,6 +585,7 @@ PACKAGE_URL=''
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
 with_linux_headers_src
+enable_libsanitizer
 with_qemu_src
 with_gdb_src
 with_musl_src
@@ -692,6 +693,7 @@ with_musl_src
 with_gdb_src
 with_qemu_src
 with_linux_headers_src
+enable_libsanitizer
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1329,6 +1331,7 @@ Optional Features:
                           slow, only enable it when developing gcc
                           [--disable-gcc-checking]
   --disable-gdb           Don't build GDB, as it's not upstream
+  --enable-libsanitizer   Build libsanitizer, which only supports rv64
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -3674,6 +3677,23 @@ else
 
 fi
 
+
+# Check whether --enable-libsanitizer was given.
+if test "${enable_libsanitizer+set}" = set; then :
+  enableval=$enable_libsanitizer;
+else
+  enable_libsanitizer=no
+
+fi
+
+
+if test "x$enable_libsanitizer" != xno; then :
+  enable_libsanitizer=--enable-libsanitizer
+
+else
+  enable_libsanitizer=--disable-libsanitizer
+
+fi
 
 if test "x$with_linux_headers_src" != xdefault; then :
   with_linux_headers_src=$with_linux_headers_src

--- a/configure.ac
+++ b/configure.ac
@@ -242,6 +242,17 @@ AC_ARG_WITH(linux-headers-src,
 	[with_linux_headers_src=default]
 	)
 
+AC_ARG_ENABLE(libsanitizer,
+	[AS_HELP_STRING([--enable-libsanitizer],
+		[Build libsanitizer, which only supports rv64])],
+	[],
+	[enable_libsanitizer=no]
+	)
+
+AS_IF([test "x$enable_libsanitizer" != xno],
+	[AC_SUBST(enable_libsanitizer, --enable-libsanitizer)],
+	[AC_SUBST(enable_libsanitizer, --disable-libsanitizer)])
+
 AS_IF([test "x$with_linux_headers_src" != xdefault],
 	[AC_SUBST(with_linux_headers_src,$with_linux_headers_src)],
 	[AC_SUBST(with_linux_headers_src,"\$(srcdir)/linux-headers/include")])


### PR DESCRIPTION
This lets users select whether or not to build libsanitizer, which
currently does not support rv32 and thus can't be enabled by default.

Signed-off-by: Palmer Dabbelt <palmer@rivosinc.com>