### PR TITLE
Allow users to build QEMU with system-mode emulation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -36,6 +36,7 @@ WITH_TUNE ?= @WITH_TUNE@
 WITH_ISA_SPEC ?= @WITH_ISA_SPEC@
 SYSROOT := $(INSTALL_DIR)/sysroot
 ENABLE_LIBSANITIZER ?= @enable_libsanitizer@
+QEMU_TARGETS ?= @qemu_targets@
 
 SHELL := /bin/sh
 AWK := @GAWK@
@@ -848,7 +849,7 @@ stamps/build-qemu: $(QEMU_SRCDIR) $(QEMU_SRC_GIT)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \
 		--prefix=$(INSTALL_DIR) \
-		--target-list=riscv64-linux-user,riscv32-linux-user \
+		--target-list=$(QEMU_TARGETS) \
 		--interp-prefix=$(INSTALL_DIR)/sysroot \
 		--python=python3
 	$(MAKE) -C $(notdir $@)

--- a/configure
+++ b/configure
@@ -584,8 +584,9 @@ PACKAGE_URL=''
 
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
-with_linux_headers_src
+qemu_targets
 enable_libsanitizer
+with_linux_headers_src
 with_qemu_src
 with_gdb_src
 with_musl_src
@@ -694,6 +695,7 @@ with_gdb_src
 with_qemu_src
 with_linux_headers_src
 enable_libsanitizer
+enable_qemu_system
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1332,6 +1334,7 @@ Optional Features:
                           [--disable-gcc-checking]
   --disable-gdb           Don't build GDB, as it's not upstream
   --enable-libsanitizer   Build libsanitizer, which only supports rv64
+  --enable-qemu-system    Build qemu with system-mode emulation
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -3678,6 +3681,14 @@ else
 fi
 
 
+if test "x$with_linux_headers_src" != xdefault; then :
+  with_linux_headers_src=$with_linux_headers_src
+
+else
+  with_linux_headers_src="\$(srcdir)/linux-headers/include"
+
+fi
+
 # Check whether --enable-libsanitizer was given.
 if test "${enable_libsanitizer+set}" = set; then :
   enableval=$enable_libsanitizer;
@@ -3695,11 +3706,20 @@ else
 
 fi
 
-if test "x$with_linux_headers_src" != xdefault; then :
-  with_linux_headers_src=$with_linux_headers_src
+# Check whether --enable-qemu_system was given.
+if test "${enable_qemu_system+set}" = set; then :
+  enableval=$enable_qemu_system;
+else
+  enable_qemu_system=no
+
+fi
+
+
+if test "x$enable_qemu_system" != xno; then :
+  qemu_targets=riscv64-linux-user,riscv32-linux-user,riscv64-softmmu,riscv32-softmmu
 
 else
-  with_linux_headers_src="\$(srcdir)/linux-headers/include"
+  qemu_targets=riscv64-linux-user,riscv32-linux-user
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -257,4 +257,15 @@ AS_IF([test "x$enable_libsanitizer" != xno],
 	[AC_SUBST(enable_libsanitizer, --enable-libsanitizer)],
 	[AC_SUBST(enable_libsanitizer, --disable-libsanitizer)])
 
+AC_ARG_ENABLE(qemu_system,
+	[AS_HELP_STRING([--enable-qemu-system],
+		[Build qemu with system-mode emulation])],
+	[],
+	[enable_qemu_system=no]
+	)
+
+AS_IF([test "x$enable_qemu_system" != xno],
+	[AC_SUBST(qemu_targets, [riscv64-linux-user,riscv32-linux-user,riscv64-softmmu,riscv32-softmmu])],
+	[AC_SUBST(qemu_targets, [riscv64-linux-user,riscv32-linux-user])])
+
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -242,6 +242,10 @@ AC_ARG_WITH(linux-headers-src,
 	[with_linux_headers_src=default]
 	)
 
+AS_IF([test "x$with_linux_headers_src" != xdefault],
+	[AC_SUBST(with_linux_headers_src,$with_linux_headers_src)],
+	[AC_SUBST(with_linux_headers_src,"\$(srcdir)/linux-headers/include")])
+
 AC_ARG_ENABLE(libsanitizer,
 	[AS_HELP_STRING([--enable-libsanitizer],
 		[Build libsanitizer, which only supports rv64])],
@@ -252,9 +256,5 @@ AC_ARG_ENABLE(libsanitizer,
 AS_IF([test "x$enable_libsanitizer" != xno],
 	[AC_SUBST(enable_libsanitizer, --enable-libsanitizer)],
 	[AC_SUBST(enable_libsanitizer, --disable-libsanitizer)])
-
-AS_IF([test "x$with_linux_headers_src" != xdefault],
-	[AC_SUBST(with_linux_headers_src,$with_linux_headers_src)],
-	[AC_SUBST(with_linux_headers_src,"\$(srcdir)/linux-headers/include")])
 
 AC_OUTPUT


### PR DESCRIPTION
I'm trying to clean up some of my test scripts, and one issue is that
I've got two QEMU builds: one for user-mode emulation and one for
system-mode emulation.  This adds an autoconf flag that allows me to
avoid the duplication.