### PR TITLE
Switch binutils to upstream 2.39 branch and rename the folder name

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
-[submodule "riscv-binutils"]
-	path = riscv-binutils
-	url = https://github.com/riscv-collab/riscv-binutils-gdb.git
-	branch = riscv-binutils-2.38
+[submodule "binutils"]
+	path = binutils
+	url = https://sourceware.org/git/binutils-gdb.git
+	branch = binutils-2_39-branch
 [submodule "riscv-gcc"]
 	path = riscv-gcc
 	url = https://github.com/riscv-collab/riscv-gcc.git

--- a/configure
+++ b/configure
@@ -3591,7 +3591,7 @@ fi
   with_binutils_src=$with_binutils_src
 
 else
-  with_binutils_src="\$(srcdir)/riscv-binutils"
+  with_binutils_src="\$(srcdir)/binutils"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -236,7 +236,7 @@ AC_DEFUN([AX_ARG_WITH_SRC],
 	}])
 
 AX_ARG_WITH_SRC(gcc, riscv-gcc)
-AX_ARG_WITH_SRC(binutils, riscv-binutils)
+AX_ARG_WITH_SRC(binutils, binutils)
 AX_ARG_WITH_SRC(newlib, newlib)
 AX_ARG_WITH_SRC(glibc, glibc)
 AX_ARG_WITH_SRC(musl, musl)


### PR DESCRIPTION
We don't hold any local changes since 2.38, so I think it's time to switch to upstream's repo.
