### PR TITLE
Update the riscv allowlist for gcc12.1-binutils 2.39

### DIFF
--- a/test/allowlist/binutils/common.log
+++ b/test/allowlist/binutils/common.log
@@ -1,18 +1,1 @@
 #
-# Following fail cases is cause by mismatch ABI,
-# because -march/-mabi didn't pass to as/ld.
-#
-FAIL: --gc-sections with --defsym
-FAIL: --gc-sections with KEEP
-FAIL: --gc-sections with __start_SECTIONNAME
-FAIL: ld-plugin/lto-3r
-FAIL: ld-plugin/lto-5r
-FAIL: PR ld/19317 (2)
-FAIL: PR ld/19317 (3)
-FAIL: LTO 5 symbol
-FAIL: LTO 3b
-FAIL: LTO 5
-#
-# .align insert nop cause unexpected size.
-#
-FAIL: ld-scripts/size-1

--- a/test/allowlist/binutils/glibc.log
+++ b/test/allowlist/binutils/glibc.log
@@ -1,15 +1,9 @@
 #
 # Missing a relaxation to convert PC-relative GOT references to
-# local symbols to PC-relative direct references.
+# local symbols to PC-relative direct references.needs a new 
+# relaxation and maybe a new relocation to eliminate tprel 
+# relocations in pie mode.
 #
 # This is an optimization, not a correctness issue.
-#
-FAIL: indirect5c dynsym
-FAIL: indirect5d dynsym
-#
-# Similarly to the above case, needs a new relaxation and maybe a new relocation
-# to eliminate tprel relocations in pie mode.
-#
-# This is an optimization, not a correctness issue too.
 #
 FAIL: Build pr22263-1

--- a/test/allowlist/binutils/newlib.log
+++ b/test/allowlist/binutils/newlib.log
@@ -1,9 +1,4 @@
 #
-# -shared unsupported on bare-metal toolchain
-#
-FAIL: Build libpr23818.so
-FAIL: Build libpr23958.so
-#
 # XXX: Unknown reason.
 #
 FAIL: Build pr22983

--- a/test/allowlist/gcc/common.log
+++ b/test/allowlist/gcc/common.log
@@ -14,16 +14,29 @@ XPASS: gcc.dg/attr-alloc_size-11.c
 #
 FAIL: c-c++-common/spec-barrier-1.c
 #
-# XXX: Need review.
+# Upstream fail cases due to target check with 'vect_slp_v2hi_store_align' and 'vect_slp_v4hi_store_unalign'
 #
-FAIL: gcc.dg/debug/dwarf2/inline5.c
+FAIL: gcc.dg/Warray-bounds-48.c
+FAIL: gcc.dg/Wzero-length-array-bounds-2.c
+FAIL: gcc.dg/uninit-pred-9_b.c
+XPASS: gcc.dg/uninit-pred-7_a.c
+# Upstream regression,
+# Patch by Palmer:
+#   https://gcc.gnu.org/pipermail/gcc-patches/2022-May/593995.html
+# Discuss in:
+#   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102892
+FAIL: gcc.dg/analyzer/pr104308.c
+FAIL: gcc.dg/pr102892-1.c
 #
-# We're optimizing something that shouldn't be optimized.
+# Upstream fail cases due to tree dump check
 #
-XPASS: gcc.dg/graphite/pr69728.c
+FAIL: gcc.dg/tree-ssa/ssa-sink-18.c
 #
-# Upstream regression, PR 90811.
-# Patch under review:
-#   https://gcc.gnu.org/pipermail/gcc-patches/2020-April/543798.html
+# Upstream fixed cases
 #
-FAIL: gfortran.dg/pr45636.f90
+# By Palmer:
+#   https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=010af1040bcf4870c8f1aac88a7b1538f622858b
+FAIL: gcc.dg/debug/btf/btf-datasec-1.c
+# By Jiawei:
+#   https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=dc32901a0221a43e121591b9819b4e33bcc2fd0a
+FAIL: g++.dg/opt/const7.C

--- a/test/allowlist/gcc/glibc.ilp32.log
+++ b/test/allowlist/gcc/glibc.ilp32.log
@@ -1,5 +1,2 @@
-FAIL: gfortran.dg/matmul_15.f90   -O  execution test
-FAIL: gfortran.dg/ieee/ieee_2.f90
-FAIL: gfortran.dg/ieee/large_2.f90
-FAIL: gfortran.dg/ieee/large_3.F90
-FAIL: gfortran.dg/ieee/rounding_1.f90
+FAIL: c-c++-common/goacc/kernels-decompose-pr100400-1-2.c
+XPASS: c-c++-common/goacc/kernels-decompose-pr100400-1-2.c

--- a/test/allowlist/gcc/glibc.log
+++ b/test/allowlist/gcc/glibc.log
@@ -1,30 +1,10 @@
 #
-# Signal related bug, might be mismatch siginfo?
-#
-FAIL: g++.dg/ext/cleanup-8.C
-FAIL: g++.dg/ext/cleanup-9.C
-FAIL: g++.dg/ext/cleanup-10.C
-FAIL: g++.dg/ext/cleanup-11.C
-FAIL: gcc.dg/cleanup-8.c
-FAIL: gcc.dg/cleanup-9.c
-FAIL: gcc.dg/cleanup-10.c
-FAIL: gcc.dg/cleanup-11.c
-#
 # XXX: Need review why.
 #
+FAIL: c-c++-common/goacc/kernels-decompose-pr100400-1-2.c
+XPASS: c-c++-common/goacc/kernels-decompose-pr100400-1-2.c
 FAIL: gfortran.dg/ieee/ieee_6.f90
-#
-# ieee_1.F90 is a QEMU bug: https://github.com/riscv/riscv-qemu/issues/64
-#
-FAIL: gfortran.dg/ieee/ieee_1.F90
 #
 # Synchronization problem.
 #
 FAIL: gcc.dg/tree-prof/time-profiler-2.c
-#
-# TLS related testcase might random fail on qemu
-# But it's hard to reproduce and seems only happen on qemu.
-# So put those case here for now.
-#
-FAIL: g++.dg/tls/thread_local4.C
-FAIL: g++.dg/tls/thread_local4g.C

--- a/test/allowlist/gcc/glibc.lp64.log
+++ b/test/allowlist/gcc/glibc.lp64.log
@@ -1,5 +1,2 @@
-FAIL: gfortran.dg/matmul_15.f90   -O  execution test
-FAIL: gfortran.dg/ieee/ieee_2.f90
-FAIL: gfortran.dg/ieee/large_2.f90
-FAIL: gfortran.dg/ieee/large_3.F90
-FAIL: gfortran.dg/ieee/rounding_1.f90
+FAIL: c-c++-common/goacc/kernels-decompose-pr100400-1-2.c
+XPASS: c-c++-common/goacc/kernels-decompose-pr100400-1-2.c

--- a/test/allowlist/gcc/lp64.log
+++ b/test/allowlist/gcc/lp64.log
@@ -1,5 +1,5 @@
 #
 # fesetround not work with soft-fp
 #
-FAIL: gcc.dg/torture/fp-int-convert-timode-3.c
-FAIL: gcc.dg/torture/fp-int-convert-timode-4.c
+#FAIL: gcc.dg/torture/fp-int-convert-timode-3.c
+#FAIL: gcc.dg/torture/fp-int-convert-timode-4.c

--- a/test/allowlist/gcc/newlib.log
+++ b/test/allowlist/gcc/newlib.log
@@ -1,7 +1,6 @@
 #
 # We didn't init thread pointer in qemu nor newlib.
 #
-FAIL: gcc.dg/tls/pr78796.c execution test
 FAIL: g++.dg/cpp2a/decomp2.C
 #
 # freopen with stdout not work correctly for newlib
@@ -9,10 +8,6 @@ FAIL: g++.dg/cpp2a/decomp2.C
 FAIL: gcc.c-torture/execute/user-printf.c
 FAIL: gcc.c-torture/execute/fprintf-2.c
 FAIL: gcc.c-torture/execute/printf-2.c
-#
-# Missing dg-require-effective-target shared
-#
-FAIL: g++.dg/lto/pr87906 cp_lto_pr87906_0.o-cp_lto_pr87906_1.o link,  -O -fPIC -flto
 #
 # -lc not enough to link final executable for newlib.
 #

--- a/test/allowlist/gcc/rv64.log
+++ b/test/allowlist/gcc/rv64.log
@@ -1,5 +1,4 @@
 #
 # XXX: Need review
 #
-FAIL: gcc.dg/tree-ssa/pr84512.c
 XPASS: gcc.dg/tree-ssa/ssa-fre-3.c


### PR DESCRIPTION
Update the riscv allowlist for gcc12.1-binutils 2.39, tested with target rv64gc-lp64d rv64gc-lp64 rv32gc-ilp32d rv32gc-ilp32, checked newlib and glibc cases.