### PR TITLE
Quick fix sim pk build failure for RV32.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -825,7 +825,8 @@ stamps/build-pk32: $(PK_SRCDIR) stamps/build-gcc-newlib-stage2
 	cd $(notdir $@) && $</configure \
 		--prefix=$(INSTALL_DIR) \
 		--host=$(NEWLIB_TUPLE) \
-		--with-arch=rv32i
+		--with-arch=rv32imafdc \
+		--with-abi=ilp32f
 	$(MAKE) -C $(notdir $@)
 	cp $(notdir $@)/pk $(INSTALL_DIR)/$(NEWLIB_TUPLE)/bin/pk32
 	mkdir -p $(dir $@)

--- a/Makefile.in
+++ b/Makefile.in
@@ -825,7 +825,7 @@ stamps/build-pk32: $(PK_SRCDIR) stamps/build-gcc-newlib-stage2
 	cd $(notdir $@) && $</configure \
 		--prefix=$(INSTALL_DIR) \
 		--host=$(NEWLIB_TUPLE) \
-		--with-arch=rv32gc
+		--with-arch=rv32i
 	$(MAKE) -C $(notdir $@)
 	cp $(notdir $@)/pk $(INSTALL_DIR)/$(NEWLIB_TUPLE)/bin/pk32
 	mkdir -p $(dir $@)


### PR DESCRIPTION
* Fix #1087.
* The riscv-pk repo can only be built by rv32i.
* Change configure to rv32i to make SIM=spike option happy for multilib.

Signed-off-by: Pan Li <pan2.li@intel.com>