### PR TITLE
Bump gcc branch to 12.2 release.

### DIFF
--- a/test/allowlist/gcc/common.log
+++ b/test/allowlist/gcc/common.log
@@ -30,6 +30,9 @@ FAIL: gcc.dg/pr102892-1.c
 #
 # Upstream fail cases due to tree dump check
 #
+# Patch by Palmer:
+# https://gcc.gnu.org/pipermail/gcc-patches/2022-September/600932.html
+#
 FAIL: gcc.dg/tree-ssa/ssa-sink-18.c
 #
 # Upstream fixed cases
@@ -39,4 +42,6 @@ FAIL: gcc.dg/tree-ssa/ssa-sink-18.c
 FAIL: gcc.dg/debug/btf/btf-datasec-1.c
 # By Jiawei:
 #   https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=dc32901a0221a43e121591b9819b4e33bcc2fd0a
+#   https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=b18e5d7e5f9df69759f0fbc2bed91d5e51313e79
 FAIL: g++.dg/opt/const7.C
+FAIL: gcc.target/riscv/pr105666.c

--- a/test/allowlist/gcc/common.log
+++ b/test/allowlist/gcc/common.log
@@ -42,6 +42,6 @@ FAIL: gcc.dg/tree-ssa/ssa-sink-18.c
 FAIL: gcc.dg/debug/btf/btf-datasec-1.c
 # By Jiawei:
 #   https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=dc32901a0221a43e121591b9819b4e33bcc2fd0a
-#   https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=b18e5d7e5f9df69759f0fbc2bed91d5e51313e79
 FAIL: g++.dg/opt/const7.C
+#   https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=b18e5d7e5f9df69759f0fbc2bed91d5e51313e79
 FAIL: gcc.target/riscv/pr105666.c


### PR DESCRIPTION
Bump gcc branch to 12.2 release. Update allowlist with new upstream patchs.