### PR TITLE
Makefile.in: Adjust permission error message

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -203,9 +203,9 @@ build-sim: $(SIM_STAMP)
 stamps/check-write-permission:
 	mkdir -p $(INSTALL_DIR)/.test || \
 		(echo "Sorry, you don't have permission to write to" \
-		 "'$(INSTALL_DIR)', use --prefix to specify" \
-		 "another path, or use 'sudo make' if you *REALLY* want to" \
-		 "install into '$(INSTALL_DIR)'" && exit 1)
+		 "'$(INSTALL_DIR)'. Please make sure that the location is " \
+		 "writable or use --prefix to specify another destination.'" \
+		 && exit 1)
 	rm -r $(INSTALL_DIR)/.test
 	mkdir -p $(dir $@) && touch $@
 


### PR DESCRIPTION
We should not encourage people to call "sudo make". Let's drop that recommendation in case of permission errors.
