### PR TITLE
gitmodules: Fix tracking branch for GCC 12

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "gcc"]
 	path = gcc
 	url = https://gcc.gnu.org/git/gcc.git
-	branch = releases/gcc-12.1.0
+	branch = releases/gcc-12
 [submodule "glibc"]
 	path = glibc
 	url = https://sourceware.org/git/glibc.git


### PR DESCRIPTION
A recent commit bumped the GCC version to 12.2, but adjusting the tracking branch in .gitmodules was forgotten. Let's fix this and set the tracking branch to gcc-12 (note that there are no release branches for minor version releases).