### PR TITLE
musl: add missing submodule auto-initialization

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:     [ubuntu-18.04, ubuntu-20.04]
+        os:     [ubuntu-20.04, ubuntu-22.04]
         mode:   [newlib, linux, musl]
         target: [rv32gc-ilp32d, rv64gc-lp64d]
         exclude:

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:     [ubuntu-18.04, ubuntu-20.04]
+        os:     [ubuntu-20.04, ubuntu-22.04]
         mode:   [newlib, linux, musl]
         target: [rv32gc-ilp32d, rv64gc-lp64d]
         exclude:

--- a/Makefile.in
+++ b/Makefile.in
@@ -252,6 +252,12 @@ else
 GLIBC_SRC_GIT :=
 endif
 
+ifeq ($(findstring $(srcdir),$(MUSL_SRCDIR)),$(srcdir))
+MUSL_SRC_GIT := $(MUSL_SRCDIR)/.git
+else
+MUSL_SRC_GIT :=
+endif
+
 ifeq ($(findstring $(srcdir),$(QEMU_SRCDIR)),$(srcdir))
 QEMU_SRC_GIT := $(QEMU_SRCDIR)/.git
 else
@@ -742,7 +748,7 @@ stamps/build-gcc-musl-stage1: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-binutils
 	$(MAKE) -C $(notdir $@) inhibit-libc=true install-target-libgcc
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-musl-linux-headers: $(MUSL_SRCDIR) stamps/build-gcc-musl-stage1
+stamps/build-musl-linux-headers: $(MUSL_SRCDIR) $(MUSL_SRC_GIT) stamps/build-gcc-musl-stage1
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && CC="$(MUSL_CC_FOR_TARGET)" $</configure \
@@ -755,7 +761,7 @@ stamps/build-musl-linux-headers: $(MUSL_SRCDIR) stamps/build-gcc-musl-stage1
 	$(MAKE) -C $(notdir $@) install-headers
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-musl-linux: $(MUSL_SRCDIR) stamps/build-gcc-musl-stage1
+stamps/build-musl-linux: $(MUSL_SRCDIR) $(MUSL_SRC_GIT) stamps/build-gcc-musl-stage1
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && \


### PR DESCRIPTION
When I added the musl submodule a while ago in #1032, I apparently forgot to add the auto-initialization part in [Makefile.in](https://github.com/riscv-collab/riscv-gnu-toolchain/blob/master/Makefile.in).
This became evident in issue #1136.

This pull request fixes the issue and allows the musl submodule to be initialized automatically at build time if required.