### PR TITLE
Switch musl upstream URL from git:// to https://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,7 +26,7 @@
 	url = https://gitlab.com/qemu-project/qemu.git
 [submodule "musl"]
 	path = musl
-	url = git://git.musl-libc.org/musl
+	url = https://git.musl-libc.org/git/musl
 	branch = master
 [submodule "spike"]
 	path = spike


### PR DESCRIPTION
This was the only such upstream URL and it caused issues for anyone
attempting to use it behind a proxy.

Fixes #1155.
