### PR TITLE
Support testing zdinx/zfinx/zhinx.

### DIFF
--- a/scripts/march-to-cpu-opt
+++ b/scripts/march-to-cpu-opt
@@ -13,6 +13,9 @@ EXT_OPTS = {
   "zve64f":          "Zve64f=true",
   "zfh":             "Zfh=true",
   "zfhmin":             "Zfhmin=true",
+  "zhinx":           "zhinx=true",
+  "zfinx":           "zfinx=true",
+  "zdinx":           "zdinx=true",
 }
 
 SUPPORTTED_EXTS = "iemafdcbvph"
@@ -124,9 +127,15 @@ def conver_arch_to_qemu_cpu_opt(march):
     if vlen != 0:
         cpu_opt.append("vlen=%d" % vlen)
 
+    disable_all_fd = False
     for ext in ext_dict.keys():
         if ext in EXT_OPTS:
             cpu_opt.append(EXT_OPTS[ext])
+        if ext in ['zhinx', 'zfinx', 'zdinx']:
+            disable_all_fd = True
+    if disable_all_fd:
+        cpu_opt.append("f=false")
+        cpu_opt.append("d=false")
     return ",".join(cpu_opt)
 
 def selftest():


### PR DESCRIPTION
- We don't set correct qemu option for zdinx/zfinx/zhinx, this patch is fixing the march-to-cpu-opt, which is a script translate -march string to qemu options.

NOTE: I use that to verifying zfinx patches for GCC.