### PR TITLE
Add support to build LLVM/clang with C and C++ support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,3 +36,7 @@
 	path = pk
 	url = https://github.com/riscv-software-src/riscv-pk.git
 	branch = master
+[submodule "llvm"]
+	path = llvm
+	url = https://github.com/llvm/llvm-project.git
+	branch = release/15.x

--- a/Makefile.in
+++ b/Makefile.in
@@ -13,6 +13,7 @@ QEMU_SRCDIR := @with_qemu_src@
 SPIKE_SRCDIR := @with_spike_src@
 PK_SRCDIR := @with_pk_src@
 DEJAGNU_SRCDIR := @with_dejagnu_src@
+LLVM_SRCDIR := @with_llvm_src@
 
 SIM ?= @WITH_SIM@
 
@@ -117,8 +118,16 @@ newlib: stamps/build-gdb-newlib
 linux: stamps/build-gdb-linux
 endif
 linux-native: stamps/build-gcc-linux-native
+ifeq (@enable_llvm@,--enable-llvm)
+all: stamps/build-llvm-@default_target@
+newlib: stamps/build-llvm-newlib
+linux: stamps/build-llvm-linux
+ifeq (@multilib_flags@,--enable-multilib)
+$(error "Setting multilib flags for LLVM builds is not supported.")
+endif
+endif
 
-.PHONY: build-binutils build-gdb build-gcc1 build-libc build-gcc2 build-qemu
+.PHONY: build-binutils build-gdb build-gcc1 build-libc build-gcc2 build-qemu build-llvm
 build-binutils: stamps/build-binutils-@default_target@
 build-gdb: stamps/build-gdb-@default_target@
 build-gcc%: stamps/build-gcc-@default_target@-stage%
@@ -129,6 +138,7 @@ build-libc: stamps/build-newlib stamps/build-newlib-nano \
 	stamps/merge-newlib-nano
 endif
 build-qemu: stamps/build-qemu
+build-llvm: stamps/build-llvm-@default_target@
 
 REGRESSION_TEST_LIST = gcc
 
@@ -278,6 +288,12 @@ ifeq ($(findstring $(srcdir),$(DEJAGNU_SRCDIR)),$(srcdir))
 DEJAGNU_SRC_GIT := $(DEJAGNU_SRCDIR)/.git
 else
 DEJAGNU_SRC_GIT :=
+endif
+
+ifeq ($(findstring $(srcdir),$(LLVM_SRCDIR)),$(srcdir))
+LLVM_SRC_GIT := $(LLVM_SRCDIR)/.git
+else
+LLVM_SRC_GIT :=
 endif
 
 ifneq ("$(wildcard $(GCC_SRCDIR)/.git)","")
@@ -884,6 +900,42 @@ stamps/build-qemu: $(QEMU_SRCDIR) $(QEMU_SRC_GIT)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@)
 	date > $@
+
+stamps/build-llvm-linux: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) \
+                         stamps/build-gcc-linux-stage2
+	# We have the following situation:
+	# - sysroot directory: $(INSTALL_DIR)/sysroot
+	# - GCC install directory: $(INSTALL_DIR)
+	# However, LLVM does not allow to set a GCC install prefix
+	# (-DGCC_INSTALL_PREFIX) if a sysroot (-DDEFAULT_SYSROOT) is set
+	# (the GCC install prefix will be ignored silently).
+	# Without a proper sysroot path feature.h won't be found by clang.
+	# Without a proper GCC install directory libgcc won't be found.
+	# As a workaround we have to merge both paths:
+	mkdir -p $(SYSROOT)/lib/
+	ln -s $(INSTALL_DIR)/lib/gcc $(SYSROOT)/lib/gcc
+	rm -rf $@ $(notdir $@)
+	mkdir $(notdir $@)
+	cd $(notdir $@) && \
+	    cmake $(LLVM_SRCDIR)/llvm \
+	    -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR) \
+	    -DCMAKE_BUILD_TYPE=Release \
+	    -DLLVM_TARGETS_TO_BUILD="RISCV" \
+	    -DLLVM_ENABLE_PROJECTS="clang;lld" \
+	    -DLLVM_ENABLE_RUNTIMES="compiler-rt;libcxx;libcxxabi;libunwind" \
+	    -DLLVM_DEFAULT_TARGET_TRIPLE="$(LINUX_TUPLE)" \
+	    -DDEFAULT_SYSROOT="$(INSTALL_DIR)/sysroot" \
+	    -DLLVM_RUNTIME_TARGETS=$(call make_tuple,$(XLEN),linux-gnu) \
+	    -DLLVM_INSTALL_TOOLCHAIN_ONLY=On \
+	    -DLLVM_PARALLEL_LINK_JOBS=4
+	$(MAKE) -C $(notdir $@)
+	$(MAKE) -C $(notdir $@) install
+	cd $(INSTALL_DIR)/bin && ln -s clang $(LINUX_TUPLE)-clang
+	mkdir -p $(dir $@) && touch $@
+
+stamps/build-llvm-newlib:
+	echo "Building LLVM is only supported in combination with a Linux toolchain."
+	exit 1
 
 stamps/build-dejagnu: $(DEJAGNU_SRCDIR) $(DEJAGNU_SRC_GIT)
 	rm -rf $@ $(notdir $@)

--- a/Makefile.in
+++ b/Makefile.in
@@ -296,6 +296,12 @@ else
 LLVM_SRC_GIT :=
 endif
 
+ifeq ($(findstring $(srcdir),$(LLVM_SRCDIR)),$(srcdir))
+LLVM_SRC_GIT := $(LLVM_SRCDIR)/.git
+else
+LLVM_SRC_GIT :=
+endif
+
 ifneq ("$(wildcard $(GCC_SRCDIR)/.git)","")
 GCCPKGVER := g$(shell git -C $(GCC_SRCDIR) describe --always --dirty --exclude '*')
 else

--- a/Makefile.in
+++ b/Makefile.in
@@ -907,8 +907,43 @@ stamps/build-qemu: $(QEMU_SRCDIR) $(QEMU_SRC_GIT)
 	mkdir -p $(dir $@)
 	date > $@
 
+stamps/build-llvm-linux-stage1: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) \
+                                stamps/build-gcc-linux-stage2
+	rm -rf $@ $(notdir $@)
+	mkdir $(notdir $@)
+	# Build clang and lld (and nothing else)
+	cd $(notdir $@) && cmake $(LLVM_SRCDIR)/llvm \
+		-DCLANG_INCLUDE_DOCS=OFF \
+		-DCLANG_TOOL_CLANG_IMPORT_TEST_BUILD=OFF \
+		-DCLANG_TOOL_C_INDEX_TEST_BUILD=OFF \
+		-DCLANG_TOOL_ARCMT_TEST_BUILD=OFF \
+		-DCLANG_TOOL_C_ARCMT_TEST_BUILD=OFF \
+		-DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR)/host \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DLLVM_ENABLE_BINDINGS=OFF \
+		-DLLVM_ENABLE_LIBXML2=OFF \
+		-DLLVM_ENABLE_OCAMLDOC=OFF \
+		-DLLVM_ENABLE_PROJECTS="clang;lld" \
+		-DLLVM_ENABLE_Z3_SOLVER=OFF \
+		-DLLVM_ENABLE_ZSTD=OFF \
+		-DLLVM_INCLUDE_BENCHMARKS=OFF \
+		-DLLVM_INCLUDE_DOCS=OFF \
+		-DLLVM_INCLUDE_EXAMPLES=OFF \
+		-DLLVM_INCLUDE_GO_TESTS=OFF \
+		-DLLVM_INCLUDE_TESTS=OFF \
+		-DLLVM_INSTALL_TOOLCHAIN_ONLY=On \
+		-DLLVM_TOOL_LLVM_LTO_BUILD=OFF \
+		-DLLVM_TOOL_LLVM_LTO2_BUILD=OFF \
+		-DLLVM_TOOL_REMARKS_SHLIB_BUILD=OFF \
+		-DLLVM_TOOL_LTO_BUILD=OFF
+	$(MAKE) -C $(notdir $@)
+	$(MAKE) -C $(notdir $@) install
+	mkdir -p $(dir $@) && touch $@
+
 stamps/build-llvm-linux: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) \
-                         stamps/build-gcc-linux-stage2
+                         stamps/build-llvm-linux-stage1
+	rm -rf $@ $(notdir $@)
+	mkdir $(notdir $@)
 	# We have the following situation:
 	# - sysroot directory: $(INSTALL_DIR)/sysroot
 	# - GCC install directory: $(INSTALL_DIR)
@@ -919,24 +954,38 @@ stamps/build-llvm-linux: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) \
 	# Without a proper GCC install directory libgcc won't be found.
 	# As a workaround we have to merge both paths:
 	mkdir -p $(SYSROOT)/lib/
-	ln -s $(INSTALL_DIR)/lib/gcc $(SYSROOT)/lib/gcc
-	rm -rf $@ $(notdir $@)
-	mkdir $(notdir $@)
-	cd $(notdir $@) && \
-	    cmake $(LLVM_SRCDIR)/llvm \
-	    -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR) \
-	    -DCMAKE_BUILD_TYPE=Release \
-	    -DLLVM_TARGETS_TO_BUILD="RISCV" \
-	    -DLLVM_ENABLE_PROJECTS="clang;lld" \
-	    -DLLVM_ENABLE_RUNTIMES="compiler-rt;libcxx;libcxxabi;libunwind" \
-	    -DLLVM_DEFAULT_TARGET_TRIPLE="$(LINUX_TUPLE)" \
-	    -DDEFAULT_SYSROOT="$(INSTALL_DIR)/sysroot" \
-	    -DLLVM_RUNTIME_TARGETS=$(call make_tuple,$(XLEN),linux-gnu) \
-	    -DLLVM_INSTALL_TOOLCHAIN_ONLY=On \
-	    -DLLVM_PARALLEL_LINK_JOBS=4
+	ln -sf $(INSTALL_DIR)/lib/gcc $(SYSROOT)/lib/gcc
+	# Build runtime libs
+	cd $(notdir $@) && cmake $(LLVM_SRCDIR)/llvm \
+		-DCMAKE_AR=$(INSTALL_DIR)/host/bin/llvm-ar \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_C_COMPILER=$(INSTALL_DIR)/host/bin/clang \
+		-DCMAKE_CXX_COMPILER=$(INSTALL_DIR)/host/bin/clang++ \
+		-DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR) \
+		-DCMAKE_NM=$(INSTALL_DIR)/host/bin/llvm-nm \
+		-DCMAKE_RANLIB=$(INSTALL_DIR)/host/bin/llvm-ranlib \
+		-DDEFAULT_SYSROOT="$(INSTALL_DIR)/sysroot" \
+		-DLLVM_CONFIG_PATH=$(INSTALL_DIR)/host/bin/llvm-config \
+		-DLLVM_DEFAULT_TARGET_TRIPLE="$(LINUX_TUPLE)" \
+		-DLLVM_ENABLE_PIC=False \
+		-DLLVM_ENABLE_PROJECTS="clang;lld" \
+		-DLLVM_ENABLE_RUNTIMES="compiler-rt;libcxx;libcxxabi" \
+		-DLLVM_INSTALL_TOOLCHAIN_ONLY=On \
+		-DLLVM_RUNTIME_TARGETS="$(LINUX_TUPLE)" \
+		-DLLVM_TARGETS_TO_BUILD="RISCV" \
+		-DLLVM_USE_LINKER=lld \
+		-DCOMPILER_RT_BUILD_BUILTINS=ON \
+		-DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+		-DCOMPILER_RT_BUILD_MEMPROF=OFF \
+		-DCOMPILER_RT_BUILD_PROFILE=OFF \
+		-DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+		-DCOMPILER_RT_BUILD_XRAY=OFF
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
-	cd $(INSTALL_DIR)/bin && ln -s clang $(LINUX_TUPLE)-clang
+	# Add symlinks with target-triplet prefix
+	cd $(INSTALL_DIR)/bin && ln -sf clang $(LINUX_TUPLE)-clang
+	cd $(INSTALL_DIR)/bin && ln -sf clang++ $(LINUX_TUPLE)-clang++
+	cd $(INSTALL_DIR)/bin && ln -sf flang $(LINUX_TUPLE)-flang
 	mkdir -p $(dir $@) && touch $@
 
 stamps/build-llvm-newlib:

--- a/README.md
+++ b/README.md
@@ -246,6 +246,37 @@ The command below can be used to run the glibc tests:
 
     make check-glibc-linux
 
+### LLVM / clang
+
+LLVM can be used in combination with the RISC-V GNU Compiler Toolchain
+to build RISC-V applications. To build LLVM with C and C++ support the
+configure flag `--enable-llvm` can be used.
+
+E.g. to build LLVM on top of a RV64 Linux toolchain the following commands
+can be used:
+
+  ./configure --prefix=$RISCV --enable-llvm --enable-linux
+  make
+
+Note, that a combination of `--enable-llvm` and multilib configuration flags
+is not supported.
+Also note, that building LLVM is only supported in combination with building
+a Linux toolchain.
+
+Below is an example how to build a rv64gc Linux toolchain with LLVM support,
+how to use it to build a C and a C++ application using clang, and how to
+execute the generated binaries using QEMU:
+
+    # Build rv64gc toolchain with LLVM
+    ./configure --prefix=$RISCV --enable-llvm --enable-linux --with-arch=rv64gc --with-abi=lp64d
+    make -j$(nproc) all build-sim SIM=qemu
+    # Build C application with clang
+    $RISCV/bin/clang -march=rv64imafdc -o hello_world hello_world.c
+    $RISCV/bin/qemu-riscv64 ./hello-world
+    # Build C++ application with clang
+    $RISCV/bin/clang++ -march=rv64imafdc -stdlib=libc++ -o hello_world_cpp hello_world_cpp.cxx
+    $RISCV/bin/qemu-riscv64 ./hello-world_cpp
+
 ### Development
 
 This section is only for developer or advanced user, or you want to build
@@ -296,13 +327,14 @@ For example you have a gcc in `$HOME/gcc`, use `--with-gcc-src` can specify that
 
 Here is the list of configure option for specify source tree:
 
-    --with-gcc-src
     --with-binutils-src
-    --with-newlib-src
-    --with-glibc-src
-    --with-musl-src
+    --with-gcc-src
     --with-gdb-src
+    --with-glibc-src
     --with-linux-headers-src
+    --with-llvm-src
+    --with-musl-src
+    --with-newlib-src
+    --with-pk-src
     --with-qemu-src
     --with-spike-src
-    --with-pk-src

--- a/configure
+++ b/configure
@@ -588,6 +588,7 @@ qemu_targets
 enable_libsanitizer
 with_linux_headers_src
 with_dejagnu_src
+with_llvm_src
 with_pk_src
 with_spike_src
 with_qemu_src
@@ -597,6 +598,7 @@ with_glibc_src
 with_newlib_src
 with_binutils_src
 with_gcc_src
+enable_llvm
 enable_gdb
 with_guile
 with_system_zlib
@@ -652,7 +654,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -691,6 +692,7 @@ with_host
 with_system_zlib
 with_guile
 enable_gdb
+enable_llvm
 with_gcc_src
 with_binutils_src
 with_newlib_src
@@ -701,6 +703,7 @@ with_qemu_src
 with_spike_src
 with_pk_src
 with_dejagnu_src
+with_llvm_src
 with_linux_headers_src
 enable_libsanitizer
 enable_qemu_system
@@ -751,7 +754,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1004,15 +1006,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1150,7 +1143,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1303,7 +1296,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1341,6 +1333,7 @@ Optional Features:
                           slow, only enable it when developing gcc
                           [--disable-gcc-checking]
   --disable-gdb           Don't build GDB, as it's not upstream
+  --enable-llvm           Build LLVM (clang)
   --enable-libsanitizer   Build libsanitizer, which only supports rv64
   --enable-qemu-system    Build qemu with system-mode emulation
 
@@ -1380,6 +1373,7 @@ Optional Packages:
   --with-pk-src           Set pk source path, use builtin source by default
   --with-dejagnu-src      Set dejagnu source path, use builtin source by
                           default
+  --with-llvm-src         Set llvm source path, use builtin source by default
   --with-linux-headers-src
                           Set linux-headers source path, use builtin source by
                           default
@@ -3561,6 +3555,20 @@ else
 
 fi
 
+# Check whether --enable-llvm was given.
+if test "${enable_llvm+set}" = set; then :
+  enableval=$enable_llvm; enable_llvm=yes
+fi
+
+
+if test "x$enable_llvm" != xyes; then :
+  enable_llvm=--disable-llvm
+
+else
+  enable_llvm=--enable-llvm
+
+fi
+
 
 
 {
@@ -3734,6 +3742,26 @@ else
 fi
 
 	}
+{
+
+# Check whether --with-llvm-src was given.
+if test "${with_llvm_src+set}" = set; then :
+  withval=$with_llvm_src;
+else
+  with_llvm_src=default
+
+fi
+
+	  if test "x$with_llvm_src" != xdefault; then :
+  with_llvm_src=$with_llvm_src
+
+else
+  with_llvm_src="\$(srcdir)/llvm"
+
+fi
+
+	}
+
 {
 
 # Check whether --with-dejagnu-src was given.

--- a/configure.ac
+++ b/configure.ac
@@ -221,6 +221,17 @@ AS_IF([test "x$enable_gdb" != xno],
 	[AC_SUBST(enable_gdb, --enable-gdb)],
 	[AC_SUBST(enable_gdb, --disable-gdb)])
 
+AC_ARG_ENABLE(llvm,
+	[AS_HELP_STRING([--enable-llvm],
+		[Build LLVM (clang)])],
+	[enable_llvm=yes],
+	[]
+	)
+
+AS_IF([test "x$enable_llvm" != xyes],
+	[AC_SUBST(enable_llvm, --disable-llvm)],
+	[AC_SUBST(enable_llvm, --enable-llvm)])
+
 AC_DEFUN([AX_ARG_WITH_SRC],
 	[{m4_pushdef([opt_name], with_$1_src)
 	  AC_ARG_WITH($1-src,
@@ -245,6 +256,7 @@ AX_ARG_WITH_SRC(qemu, qemu)
 AX_ARG_WITH_SRC(spike, spike)
 AX_ARG_WITH_SRC(pk, pk)
 AX_ARG_WITH_SRC(dejagnu, dejagnu)
+AX_ARG_WITH_SRC(llvm, llvm)
 
 AC_ARG_WITH(linux-headers-src,
 	[AC_HELP_STRING([--with-linux-headers-src],


### PR DESCRIPTION
We currently have a stale "llvm" branch, that does not build.
However, there is clear demand in the RISC-V toolchain community
for a working LLVM on top of a recent GNU toolchain.
In order to build such a toolchain, quite some LLVM and clang know-how is
required to avoid path issues at LLVM build time or later when using clang.
The main purpose of this commit is to demonstrate a way to combine
the RISC-V GNU toolchain repo with LLVM, with the intent to save
others hours of frustration, debugging time or support time.

CC: @kito-cheng 