### PR TITLE
Fix wrong parse script

### DIFF
--- a/scripts/march-to-cpu-opt
+++ b/scripts/march-to-cpu-opt
@@ -103,10 +103,10 @@ def get_vlen(ext_dict):
         if ext == 'v':
             vlen = max(vlen, 128)
         elif (ext.startswith('zvl') and ext[-1] == 'b'):
-            zvlen = int(arch[3:-1])
+            zvlen = int(ext[3:-1])
             vlen = max(vlen, zvlen)
         elif ext.startswith("zve"):
-            zvelen = int(arch[3:-1])
+            zvelen = int(ext[3:-1])
             vlen = max(vlen, zvelen)
     return vlen
 


### PR DESCRIPTION
If test --with-arch=rv32imc_zve128x
NameError: name 'arch' is not defined

Signed-off-by: Kwanghoon Son <kwangson@yahoo.com>