### PR TITLE
Add unittest to march-to-cpu-opt

### DIFF
--- a/scripts/march-to-cpu-opt
+++ b/scripts/march-to-cpu-opt
@@ -2,6 +2,7 @@
 
 import argparse
 import sys
+import unittest
 
 EXT_OPTS = {
   "zba":             "zba=true",
@@ -129,8 +130,22 @@ def conver_arch_to_qemu_cpu_opt(march):
             cpu_opt.append(EXT_OPTS[ext])
     return ",".join(cpu_opt)
 
+
+class TestArchStringParse(unittest.TestCase):
+    def _test(self, arch, expected_arch_list, expected_vlen=0):
+         exts = parse_march(arch)
+         vlen = get_vlen(exts)
+         self.assertEqual(expected_vlen, vlen)
+         self.assertEqual(set(expected_arch_list), set(exts.keys()))
+
+    def test_rv64gc(self):
+        self._test("rv64gc", ['i', 'm', 'a', 'f', 'd', 'c'])
+        self._test("rv32imc_zve32x", ['i', 'm', 'c', 'zve32x'], expected_vlen=32)
+        self._test("rv32imc_zve32x_zvl128b", ['i', 'm', 'c', 'zve32x', 'zvl128b'], expected_vlen=128)
+
+
 def selftest():
-    print(parse_march("rv64gc"))
+    unittest.main(argv=sys.argv[1:])
 
 def main(argv):
     opt = parse_opt(argv)


### PR DESCRIPTION
https://github.com/riscv-collab/riscv-gnu-toolchain/pull/1167 has found some bug, and I realized the testing of march-to-cpu-opt is...not well, so spend some time to improve that a little bit, it's not complete testing, but at least it's a start :P