### PR TITLE
Docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ Also available for Arch users on the AUR: [https://aur.archlinux.org/packages/ri
 
 On OS X, you can use [Homebrew](http://brew.sh) to install the dependencies:
 
-    $ brew install python3 gawk gnu-sed gmp mpfr libmpc isl zlib expat
-    $ brew tap discoteq/discoteq
-    $ brew install flock
+    $ brew install python3 gawk gnu-sed gmp mpfr libmpc isl zlib expat texinfo flock
 
 To build the glibc (Linux) on OS X, you will need to build within a case-sensitive file
 system.  The simplest approach is to create and mount a new disk image with
@@ -50,9 +48,9 @@ complete the process.
 
 ### Installation (Newlib)
 
-To build the Newlib cross-compiler, pick an install path.  If you choose,
-say, `/opt/riscv`, then add `/opt/riscv/bin` to your `PATH` now.  Then, simply
-run the following command:
+To build the Newlib cross-compiler, pick an install path (that is writeable).
+If you choose, say, `/opt/riscv`, then add `/opt/riscv/bin` to your `PATH`.
+Then, simply run the following command:
 
     ./configure --prefix=/opt/riscv
     make
@@ -61,7 +59,7 @@ You should now be able to use riscv64-unknown-elf-gcc and its cousins.
 
 ### Installation (Linux)
 
-To build the Linux cross-compiler, pick an install path (that is writeable.)
+To build the Linux cross-compiler, pick an install path (that is writeable).
 If you choose, say, `/opt/riscv`, then add `/opt/riscv/bin` to your `PATH`.
 Then, simply run the following command:
 


### PR DESCRIPTION
I tried to compile the tool chain in MacOS 13.2 (22D49) Ventura, and found three points in README that could be improved:

1. I encountered the following error when compiling on MacOS 13.2 Ventura, which was resolved after installing texinfo dependency.
```
/Volumes/case-sensitive/riscv-gnu-toolchain/binutils/missing: line 81: makeinfo: command not found
WARNING: 'makeinfo' is missing on your system.
         You should only need it if you modified a '.texi' file, or
         any other file indirectly affecting the aspect of the manual.
         You might want to install the Texinfo package:
         <http://www.gnu.org/software/texinfo/>
         The spurious makeinfo call might also be the consequence of
         using a buggy 'make' (AIX, DU, IRIX), in which case you might
         want to install GNU make:
         <http://www.gnu.org/software/make/>
make[4]: *** [doc/bfd.info] Error 127
make[3]: *** [info-recursive] Error 1
make[2]: *** [all-bfd] Error 2
make[1]: *** [all] Error 2
make: *** [stamps/build-binutils-newlib] Error 2
% brew install texinfo
```

2. The flock formula has been included in the homebrew-core, so we can directly brew install. 

For reference: https://formulae.brew.sh/formula/flock

3. When I make newlib, I also made an error because the installation path did not have write permission. I saw that a tip was added in #1171. In order to maintain consistency, I also made small changes to the Installation (Newlib) part.

So, this patch contains three minor updates:
1. Added texinfo to OS X dependency package
2. Brew tap discoteq/discoteq is no longer required to install the flock
4. Added tip in "Installation (Newlib)" to keep similar to the description in "Installation (Linux)" and fixed a typo.

Signed-off-by: Mingzheng Xing <xingmingzheng@iscas.ac.cn>