### PR TITLE
Bump Binutils version to 2.40.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "binutils"]
 	path = binutils
 	url = https://sourceware.org/git/binutils-gdb.git
-	branch = binutils-2_39-branch
+	branch = binutils-2_40-branch
 [submodule "gcc"]
 	path = gcc
 	url = https://gcc.gnu.org/git/gcc.git


### PR DESCRIPTION
Bump Binutils version to 2.40. 
Add rounding modes, FENCE sets, Zawrs extension opcodes, vendor extension XThead instructions.
Change unrecognized instructions disassemble symbols from .byte into .insn.