### PR TITLE
dejagnu: Allow source dir override

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -12,6 +12,7 @@ GDB_SRCDIR := @with_gdb_src@
 QEMU_SRCDIR := @with_qemu_src@
 SPIKE_SRCDIR := @with_spike_src@
 PK_SRCDIR := @with_pk_src@
+DEJAGNU_SRCDIR := @with_dejagnu_src@
 
 SIM ?= @WITH_SIM@
 
@@ -270,6 +271,12 @@ ifeq ($(findstring $(srcdir),$(SPIKE_SRCDIR)),$(srcdir))
 SPIKE_SRC_GIT := $(SPIKE_SRCDIR)/.git
 else
 SPIKE_SRC_GIT :=
+endif
+
+ifeq ($(findstring $(srcdir),$(DEJAGNU_SRCDIR)),$(srcdir))
+DEJAGNU_SRC_DIR := $(DEJAGNU_SRCDIR)/.git
+else
+DEJAGNU_SRC_DIR :=
 endif
 
 ifneq ("$(wildcard $(GCC_SRCDIR)/.git)","")
@@ -865,7 +872,7 @@ stamps/build-qemu: $(QEMU_SRCDIR) $(QEMU_SRC_GIT)
 	mkdir -p $(dir $@)
 	date > $@
 
-stamps/build-dejagnu: $(srcdir)/dejagnu $(srcdir)/dejagnu/.git
+stamps/build-dejagnu: $(DEJAGNU_SRCDIR) $(DEJAGNU_SRC_GIT)
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \

--- a/configure
+++ b/configure
@@ -588,6 +588,7 @@ qemu_targets
 enable_libsanitizer
 with_linux_headers_src
 with_pk_src
+with_dejagnu_src
 with_spike_src
 with_qemu_src
 with_gdb_src
@@ -699,6 +700,7 @@ with_gdb_src
 with_qemu_src
 with_spike_src
 with_pk_src
+with_dejagnu_src
 with_linux_headers_src
 enable_libsanitizer
 enable_qemu_system
@@ -3725,6 +3727,26 @@ fi
 
 else
   with_pk_src="\$(srcdir)/pk"
+
+fi
+
+	}
+
+{
+
+# Check whether --with-dejagnu-src was given.
+if test "${with_dejagnu_src+set}" = set; then :
+  withval=$with_dejagnu_src;
+else
+  with_dejagnu_src=default
+
+fi
+
+	  if test "x$with_dejagnu_src" != xdefault; then :
+  with_dejagnu_src=$with_dejagnu_src
+
+else
+  with_dejagnu_src="\$(srcdir)/dejagnu"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -244,6 +244,7 @@ AX_ARG_WITH_SRC(gdb, gdb)
 AX_ARG_WITH_SRC(qemu, qemu)
 AX_ARG_WITH_SRC(spike, spike)
 AX_ARG_WITH_SRC(pk, pk)
+AX_ARG_WITH_SRC(dejagnu, dejagnu)
 
 AC_ARG_WITH(linux-headers-src,
 	[AC_HELP_STRING([--with-linux-headers-src],


### PR DESCRIPTION
We have this feature for all other packages.
It is particularly useful to avoid pointless internet downloads for automatic builds.