### PR TITLE
dejagnu: Fix typo in var

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -274,9 +274,9 @@ SPIKE_SRC_GIT :=
 endif
 
 ifeq ($(findstring $(srcdir),$(DEJAGNU_SRCDIR)),$(srcdir))
-DEJAGNU_SRC_DIR := $(DEJAGNU_SRCDIR)/.git
+DEJAGNU_SRC_GIT := $(DEJAGNU_SRCDIR)/.git
 else
-DEJAGNU_SRC_DIR :=
+DEJAGNU_SRC_GIT :=
 endif
 
 ifneq ("$(wildcard $(GCC_SRCDIR)/.git)","")


### PR DESCRIPTION
There is a typo in a previous commit that introduced src-dir-override for DejaGnu.

I should have properly tested this before, and in fact, I did test this in the last two weeks before creating the PR.
However, I cherry-picked from a stale branch that had this typo in, when I created the dejagnu PR.
So sorry for this second PR that needs to clean up.