### PR TITLE
[NEWLIB][Cross-build]: Fix merge-newlib-nano.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -94,6 +94,7 @@ NEWLIB_CC_FOR_TARGET ?= $(NEWLIB_TUPLE)-gcc
 NEWLIB_CXX_FOR_TARGET ?= $(NEWLIB_TUPLE)-g++
 NEWLIB_TARGET_BOARDS ?= $(shell echo "$(NEWLIB_MULTILIB_NAMES)" | sed 's!\([_a-z0-9]*\)-\([_a-z0-9]*\)!riscv-sim/-march=\1/-mabi=\2/@cmodel@!g')
 NEWLIB_NANO_TARGET_BOARDS ?= $(shell echo "$(NEWLIB_MULTILIB_NAMES)" | sed 's!\([_a-z0-9]*\)-\([_a-z0-9]*\)!riscv-sim-nano/-march=\1/-mabi=\2/@cmodel@!g')
+NEWLIB_CC_FOR_MULTILIB_INFO := $(NEWLIB_CC_FOR_TARGET)
 
 MUSL_TARGET_FLAGS := $(MUSL_TARGET_FLAGS_EXTRA)
 MUSL_CC_FOR_TARGET ?= $(MUSL_TUPLE)-gcc
@@ -640,8 +641,13 @@ stamps/build-newlib-nano: $(NEWLIB_SRCDIR) $(NEWLIB_SRC_GIT) stamps/build-gcc-ne
 
 stamps/merge-newlib-nano: stamps/build-newlib-nano stamps/build-newlib
 # Copy nano library files into newlib install dir.
+	if [ -f $(INSTALL_DIR)/bin/$(NEWLIB_TUPLE)-gcc ] ; then \
+		export NEWLIB_CC_FOR_MULTILIB_INFO="$(INSTALL_DIR)/bin/$(NEWLIB_TUPLE)-gcc"; \
+	else \
+		export NEWLIB_CC_FOR_MULTILIB_INFO="$(NEWLIB_CC_FOR_TARGET)"; \
+	fi
 	set -e; \
-        for ml in `$(INSTALL_DIR)/bin/$(NEWLIB_TUPLE)-gcc --print-multi-lib`; \
+        for ml in `${NEWLIB_CC_FOR_MULTILIB_INFO} --print-multi-lib`; \
 	do \
 	    mld=`echo $${ml} | sed -e 's/;.*$$//'`; \
 	    cp $(builddir)/install-newlib-nano/$(NEWLIB_TUPLE)/lib/$${mld}/libc.a \


### PR DESCRIPTION
There is no $(NEWLIB_TUPLE)-gcc in install directory during cross-compilation process. For example,
to compile for Windows, we has to have riscv64-unknown-elf-gcc in our PATH and we has to use it with print-multi-lib to find multilib configuration, because install
folder contains only .exe files (can not be executed)

This bugfix is to check: whether compiler we already have for host - in the install directory or in the PATH.