### PR TITLE
[Makefile.in] glibc: Remove unnecessary -g option

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -13,6 +13,7 @@ QEMU_SRCDIR := @with_qemu_src@
 SPIKE_SRCDIR := @with_spike_src@
 PK_SRCDIR := @with_pk_src@
 DEJAGNU_SRCDIR := @with_dejagnu_src@
+DEBUG_INFO := @debug_info@
 
 SIM ?= @WITH_SIM@
 
@@ -372,8 +373,8 @@ endif
 	cd $(notdir $@) && \
 		CC="$(GLIBC_CC_FOR_TARGET) $($@_CFLAGS)" \
 		CXX="this-is-not-the-compiler-youre-looking-for" \
-		CFLAGS="$(CFLAGS_FOR_TARGET) -g -O2 $($@_CFLAGS)" \
-		CXXFLAGS="$(CXXFLAGS_FOR_TARGET) -g -O2 $($@_CFLAGS)" \
+		CFLAGS="$(CFLAGS_FOR_TARGET) $(DEBUG_INFO) -O2 $($@_CFLAGS)" \
+		CXXFLAGS="$(CXXFLAGS_FOR_TARGET) $(DEBUG_INFO) -O2 $($@_CFLAGS)" \
 		ASFLAGS="$(ASFLAGS_FOR_TARGET) $($@_CFLAGS)" \
 		$</configure \
 		--host=$(call make_tuple,$($@_XLEN),linux-gnu) \
@@ -788,8 +789,8 @@ stamps/build-musl-linux: $(MUSL_SRCDIR) $(MUSL_SRC_GIT) stamps/build-gcc-musl-st
 	cd $(notdir $@) && \
 		CC="$(MUSL_CC_FOR_TARGET) $($@_CFLAGS)" \
 		CXX="$(MUSL_CXX_FOR_TARGET) $($@_CFLAGS)" \
-		CFLAGS="$(CFLAGS_FOR_TARGET) -g -O2 $($@_CFLAGS)" \
-		CXXFLAGS="$(CXXFLAGS_FOR_TARGET) -g -O2 $($@_CFLAGS)" \
+		CFLAGS="$(CFLAGS_FOR_TARGET) $(DEBUG_INFO) -O2 $($@_CFLAGS)" \
+		CXXFLAGS="$(CXXFLAGS_FOR_TARGET) $(DEBUG_INFO) -O2 $($@_CFLAGS)" \
 		ASFLAGS="$(ASFLAGS_FOR_TARGET) $($@_CFLAGS)" \
 		$</configure \
 		--host=$(MUSL_TUPLE) \

--- a/configure
+++ b/configure
@@ -615,6 +615,7 @@ WITH_ISA_SPEC
 WITH_TUNE
 WITH_ABI
 WITH_ARCH
+debug_info
 default_target
 FETCHER
 FTP
@@ -676,6 +677,7 @@ ac_subst_files=''
 ac_user_opts='
 enable_option_checking
 enable_linux
+enable_debug_info
 with_arch
 with_abi
 with_tune
@@ -1335,6 +1337,7 @@ Optional Features:
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --enable-linux          set linux as the default make target
                           [--disable-linux]
+  --disable-debug-info    build glibc and musl without debug infromation
   --enable-multilib       build both RV32 and RV64 runtime libraries (only
                           RV64 for musl libc) [--disable-multilib]
   --enable-gcc-checking   Enable gcc internal checking, it will make gcc very
@@ -3293,6 +3296,23 @@ if test "x$enable_linux" != xno; then :
 
 else
   default_target=newlib
+
+fi
+
+# Check whether --enable-debug_info was given.
+if test "${enable_debug_info+set}" = set; then :
+  enableval=$enable_debug_info; disable_debug_info=yes
+else
+  disable_debug_info=no
+
+fi
+
+
+if test "x$disable_debug_info" != xno; then :
+  debug_info=""
+
+else
+  debug_info="-g"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,17 @@ AS_IF([test "x$enable_linux" != xno],
 	[AC_SUBST(default_target, linux)],
 	[AC_SUBST(default_target, newlib)])
 
+AC_ARG_ENABLE(debug_info,
+        [AS_HELP_STRING([--disable-debug-info],
+		[build glibc and musl without debug infromation])],
+        [disable_debug_info=yes],
+        [disable_debug_info=no]
+        )
+
+AS_IF([test "x$disable_debug_info" != xno],
+	[AC_SUBST(debug_info, "")],
+	[AC_SUBST(debug_info, "-g")])
+
 AC_ARG_WITH(arch,
 	[AS_HELP_STRING([--with-arch=rv64imafdc],
 		[Sets the base RISC-V ISA, defaults to rv64imafdc])],


### PR DESCRIPTION
Using llvm-objdump I found warning if file was
compiled using riscv-gcc. Examples:

warning: failed to find source riscv-glibc/csu/elf-init.c

It concerned with compilation glibc with
debug info that is unnecessary operation. If user want to have debug info, than it's easy to pass -g.

This option wasn't touched more than 7 years...