### PR TITLE
configure: change --disable-debug-info to --enable-debug-info

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -77,9 +77,9 @@ LINUX_TUPLE  ?= $(call make_tuple,$(XLEN),linux-gnu)
 NEWLIB_TUPLE ?= $(call make_tuple,$(XLEN),elf)
 MUSL_TUPLE ?= $(call make_tuple,$(XLEN),linux-musl)
 
-CFLAGS_FOR_TARGET := $(CFLAGS_FOR_TARGET_EXTRA) @target_cflags@ @cmodel@
-CXXFLAGS_FOR_TARGET := $(CXXFLAGS_FOR_TARGET_EXTRA) @target_cxxflags@ @cmodel@
-ASFLAGS_FOR_TARGET := $(ASFLAGS_FOR_TARGET_EXTRA) @cmodel@
+CFLAGS_FOR_TARGET := $(CFLAGS_FOR_TARGET_EXTRA) $(DEBUG_INFO) @target_cflags@ @cmodel@
+CXXFLAGS_FOR_TARGET := $(CXXFLAGS_FOR_TARGET_EXTRA) $(DEBUG_INFO) @target_cxxflags@ @cmodel@
+ASFLAGS_FOR_TARGET := $(ASFLAGS_FOR_TARGET_EXTRA) $(DEBUG_INFO) @cmodel@
 # --with-expat is required to enable XML support used by OpenOCD.
 BINUTILS_TARGET_FLAGS := --with-expat=yes $(BINUTILS_TARGET_FLAGS_EXTRA)
 BINUTILS_NATIVE_FLAGS := $(BINUTILS_NATIVE_FLAGS_EXTRA)
@@ -373,8 +373,8 @@ endif
 	cd $(notdir $@) && \
 		CC="$(GLIBC_CC_FOR_TARGET) $($@_CFLAGS)" \
 		CXX="this-is-not-the-compiler-youre-looking-for" \
-		CFLAGS="$(CFLAGS_FOR_TARGET) $(DEBUG_INFO) -O2 $($@_CFLAGS)" \
-		CXXFLAGS="$(CXXFLAGS_FOR_TARGET) $(DEBUG_INFO) -O2 $($@_CFLAGS)" \
+		CFLAGS="$(CFLAGS_FOR_TARGET) -O2 $($@_CFLAGS)" \
+		CXXFLAGS="$(CXXFLAGS_FOR_TARGET) -O2 $($@_CFLAGS)" \
 		ASFLAGS="$(ASFLAGS_FOR_TARGET) $($@_CFLAGS)" \
 		$</configure \
 		--host=$(call make_tuple,$($@_XLEN),linux-gnu) \
@@ -789,8 +789,8 @@ stamps/build-musl-linux: $(MUSL_SRCDIR) $(MUSL_SRC_GIT) stamps/build-gcc-musl-st
 	cd $(notdir $@) && \
 		CC="$(MUSL_CC_FOR_TARGET) $($@_CFLAGS)" \
 		CXX="$(MUSL_CXX_FOR_TARGET) $($@_CFLAGS)" \
-		CFLAGS="$(CFLAGS_FOR_TARGET) $(DEBUG_INFO) -O2 $($@_CFLAGS)" \
-		CXXFLAGS="$(CXXFLAGS_FOR_TARGET) $(DEBUG_INFO) -O2 $($@_CFLAGS)" \
+		CFLAGS="$(CFLAGS_FOR_TARGET) -O2 $($@_CFLAGS)" \
+		CXXFLAGS="$(CXXFLAGS_FOR_TARGET) -O2 $($@_CFLAGS)" \
 		ASFLAGS="$(ASFLAGS_FOR_TARGET) $($@_CFLAGS)" \
 		$</configure \
 		--host=$(MUSL_TUPLE) \

--- a/configure
+++ b/configure
@@ -1337,7 +1337,8 @@ Optional Features:
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --enable-linux          set linux as the default make target
                           [--disable-linux]
-  --disable-debug-info    build glibc and musl without debug infromation
+  --enable-debug-info     build glibc/musl/newlibc/libgcc with debug
+                          information
   --enable-multilib       build both RV32 and RV64 runtime libraries (only
                           RV64 for musl libc) [--disable-multilib]
   --enable-gcc-checking   Enable gcc internal checking, it will make gcc very
@@ -3301,14 +3302,14 @@ fi
 
 # Check whether --enable-debug_info was given.
 if test "${enable_debug_info+set}" = set; then :
-  enableval=$enable_debug_info; disable_debug_info=yes
+  enableval=$enable_debug_info; enable_debug_info=yes
 else
-  disable_debug_info=no
+  enable_debug_info=no
 
 fi
 
 
-if test "x$disable_debug_info" != xno; then :
+if test "x$enable_debug_info" != xyes; then :
   debug_info=""
 
 else

--- a/configure.ac
+++ b/configure.ac
@@ -51,13 +51,13 @@ AS_IF([test "x$enable_linux" != xno],
 	[AC_SUBST(default_target, newlib)])
 
 AC_ARG_ENABLE(debug_info,
-        [AS_HELP_STRING([--disable-debug-info],
-		[build glibc and musl without debug infromation])],
-        [disable_debug_info=yes],
-        [disable_debug_info=no]
+        [AS_HELP_STRING([--enable-debug-info],
+		[build glibc/musl/newlibc/libgcc with debug information])],
+        [enable_debug_info=yes],
+        [enable_debug_info=no]
         )
 
-AS_IF([test "x$disable_debug_info" != xno],
+AS_IF([test "x$enable_debug_info" != xyes],
 	[AC_SUBST(debug_info, "")],
 	[AC_SUBST(debug_info, "-g")])
 


### PR DESCRIPTION
As #1232 does, it add an configure option called `--disable-debug-info` which is used to disable glibc/musl library build with debug information, since there are other libraries supported in this repo such as the newlibc/libgcc, so I think it is better to add support for these library also, and for library debug information, it is not quite useful, it might be better disabled by default, so I want to change this option to `--enable-debug-info`, library will be built without debug information by default, if user want to enable debug information, just pass `--enable-debug-info`.