### PR TITLE
env: fix python3 env not found in /usr/bin

### DIFF
--- a/scripts/march-to-cpu-opt
+++ b/scripts/march-to-cpu-opt
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import sys


### PR DESCRIPTION
As discussed in https://github.com/riscv-collab/riscv-gnu-toolchain/issues/1226#issuecomment-1495222585, this patch is used to fix python3 not found in /usr/bin, let env to find a correct one.