### PR TITLE
bump gcc to 13.1 release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "gcc"]
 	path = gcc
 	url = https://gcc.gnu.org/git/gcc.git
-	branch = releases/gcc-12
+	branch = releases/gcc-13
 [submodule "glibc"]
 	path = glibc
 	url = https://sourceware.org/git/glibc.git

--- a/test/allowlist/gcc/common.log
+++ b/test/allowlist/gcc/common.log
@@ -45,3 +45,20 @@ FAIL: gcc.dg/debug/btf/btf-datasec-1.c
 FAIL: g++.dg/opt/const7.C
 #   https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=b18e5d7e5f9df69759f0fbc2bed91d5e51313e79
 FAIL: gcc.target/riscv/pr105666.c
+#
+# Bad contract. Expecting fail for ((char) -1) > 1, but char is treated as unsigned. 
+#
+FAIL: g++.dg/contracts/contracts-tmpl-spec2.C
+#
+# Everything reduces to zbb operations so checks for andi fail
+#
+FAIL: gcc.dg/pr90838.c
+# 
+# Correctly fails with z*inx conflicting with floating-point extensions
+#
+FAIL: gcc.target/riscv/arch-19.c
+#
+# Missing sign extension with slp vectorizer.
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109989
+#
+FAIL: gcc.target/riscv/promote-type-for-libcall.c

--- a/test/allowlist/gcc/newlib.log
+++ b/test/allowlist/gcc/newlib.log
@@ -17,3 +17,7 @@ FAIL: g++.dg/abi/pure-virtual1.C
 # with `-Wall`
 #
 FAIL: g++.dg/warn/Wstringop-overflow-6.C
+#
+# Test redefines mode_t, which is defined in sys/types.h
+#
+FAIL: gcc.dg/analyzer/fd-4.c


### PR DESCRIPTION
since gcc 13.1 is release at April 26, 2023, just bump to the official 13.1 release, it will introduce official support for rvv intrinsic API 1.1

see changelog in https://gcc.gnu.org/gcc-13/changes.html