### PR TITLE
Add ci jobs for make-report and make-report multilib

### DIFF
--- a/.github/setup-apt.sh
+++ b/.github/setup-apt.sh
@@ -5,4 +5,4 @@ dpkg --add-architecture i386
 apt update
 apt install -y autoconf automake autotools-dev curl python3 libmpc-dev libmpfr-dev \
             libgmp-dev gawk build-essential bison flex texinfo gperf libtool \
-            patchutils bc zlib1g-dev libexpat-dev git
+            patchutils bc zlib1g-dev libexpat-dev git ninja-build expect

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,6 +36,14 @@ jobs:
           ./configure --prefix=/opt/riscv --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]}
           sudo make -j $(nproc) ${{ matrix.mode }}
 
+      - name: make report
+        if: |
+          matrix.os == 'ubuntu-20.04'
+          && (matrix.mode == 'linux' || matrix.mode == 'newlib')
+          && matrix.target == 'rv64gc-lp64d'
+        run: |
+          sudo make report-${{ matrix.mode }} -j $(nproc)
+
       - name: tarball build
         run: tar czvf riscv.tar.gz -C /opt/ riscv/
 
@@ -52,6 +60,56 @@ jobs:
               MODE="elf";;
           esac
           echo ::set-output name=TOOLCHAIN_NAME::riscv$BITS-$MODE-${{ matrix.os }}-nightly
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}
+          path: riscv.tar.gz
+
+  build-multilib:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:     [ubuntu-20.04]
+        mode:   [newlib, linux]
+        target: [rv64gc-lp64d]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: initialize submodules
+        run: |
+          git submodule init
+          git submodule update --recursive --progress --recommend-shallow
+
+      - name: install dependencies
+        run: sudo ./.github/setup-apt.sh
+
+      - name: build toolchain
+        run: |
+          TARGET_TUPLE=($(echo ${{ matrix.target }} | tr "-" "\n"))
+          ./configure --prefix=/opt/riscv --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]} --enable-multilib
+          sudo make -j $(nproc) ${{ matrix.mode }}
+
+      - name: make report
+        run: |
+          sudo make report-${{ matrix.mode }} -j $(nproc)
+
+      - name: tarball build
+        run: tar czvf riscv.tar.gz -C /opt/ riscv/
+
+      - name: generate prebuilt toolchain name
+        id:   toolchain-name-generator
+        run: |
+          if [[ "${{ matrix.target }}" == *"32"* ]]; then BITS=32; else BITS=64; fi
+          case "${{ matrix.mode }}" in
+            "linux")
+              MODE="glibc";;
+            "musl")
+              MODE="musl";;
+            *)
+              MODE="elf";;
+          esac
+          echo ::set-output name=TOOLCHAIN_NAME::riscv$BITS-$MODE-${{ matrix.os }}-multilib-nightly
 
       - uses: actions/upload-artifact@v2
         with:

--- a/scripts/testsuite-filter
+++ b/scripts/testsuite-filter
@@ -271,7 +271,7 @@ def filter_result(tool, libc, white_list_base_dir, unexpected_results):
                 fail_count = summary[config][tool]
                 print ("%13d |" % fail_count, end='')
         print ("")
-    if any_fail:
+    if any_fail or len(summary.items()) == 0:
         return 1
     else:
         return 0


### PR DESCRIPTION
When bumping a module or making a change, it's helpful for reviewers to see if the testsuite passes (eg. #1239). Since the testsuite takes so long to run and consumes a lot of resources when doing it, it's a prime canidate for moving to a github action.
At least one tricky bug was only found on a clean build of the repo (#1243). Having pipeling testing runs would make that easier to catch and track down.

This adds `make report linux`/`newlib` and multilib `make report linux`/`newlib` testsuite runs. These runs take roughly 2-3 hours to complete.

It also changes testsuite-filter to return an error when no results are detected (this happens when testing issues like #1243).

These currently fail because testing is broken on trunk.

Example where a pipeline build passes:
https://github.com/patrick-rivos/riscv-gnu-toolchain/pull/1

Please note that it passes because the master branch was set to `cc3263a` (before #1243 - the dejagnu rollback).
