### PR TITLE
Update README.md to reflect new default ISA spec version

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Example: ```GCC_EXTRA_CONFIGURE_FLAGS=--with-gmp=/opt/gmp make linux```
 
 Possible options are: `2.2`, `20190608` and `20191213`.
 
-The default version is `2.2`.
+The default version is `20191213`.
 
 More details about this option you can refer this post [RISC-V GNU toolchain bumping default ISA spec to 20191213](https://groups.google.com/a/groups.riscv.org/g/sw-dev/c/aE1ZeHHCYf4).
 


### PR DESCRIPTION
Default ISA spec version was bumped to 20191213 in 0ae36fce64a1f9a45747e35583c8f3f6bc482693 (#1229) but it's not reflected in `README.md`.