### PR TITLE
Disable multilib ci until multilib testsuite errors are triaged

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,6 +67,7 @@ jobs:
           path: riscv.tar.gz
 
   build-multilib:
+    if: ${{ false }} # Disable until multilib errors are triaged
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Multilib testsuite runtimes were unexpectedly long ([over 4.5 hours!](https://github.com/riscv-collab/riscv-gnu-toolchain/actions/runs/5015704475/jobs/8991615263)) and will always fail since the multilib errors have not been triaged.

This PR disables multilib testing. Once those errors are triaged, we can re-enable it.

Running out of minutes isn't a concern since GitHub actions are free for public repos:
https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions
> GitHub Actions usage is free for standard GitHub-hosted runners in public repositories, and for self-hosted runners.

