### PR TITLE
Install pyelftools before testing

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -178,7 +178,7 @@ report-gdb: report-gdb-@default_target@
 ifeq ($(SIM),qemu)
 SIM_PATH:=$(srcdir)/scripts/wrapper/qemu:$(srcdir)/scripts
 SIM_PREPARE:=PATH="$(SIM_PATH):$(INSTALL_DIR)/bin:$(PATH)" RISC_V_SYSROOT="$(SYSROOT)"
-SIM_STAMP:= stamps/build-qemu
+SIM_STAMP:= stamps/build-qemu stamps/install-python-package
 else
 ifeq ($(SIM),spike)
 # Using spike simulator.
@@ -870,6 +870,10 @@ stamps/build-pk64: $(PK_SRCDIR) stamps/build-gcc-newlib-stage2
 	$(MAKE) -C $(notdir $@)
 	cp $(notdir $@)/pk $(INSTALL_DIR)/$(NEWLIB_TUPLE)/bin/pk64
 	mkdir -p $(dir $@)
+	date > $@
+
+stamps/install-python-package:
+	python3 -m pip install --user pyelftools
 	date > $@
 
 stamps/build-qemu: $(QEMU_SRCDIR) $(QEMU_SRC_GIT)


### PR DESCRIPTION
We use some non-standard python package in #1233, so we must make sure it available before run the test.

Fix #1252