### PR TITLE
Fix #1256 - git clone pk if spike used

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -270,6 +270,7 @@ endif
 
 ifeq ($(findstring $(srcdir),$(SPIKE_SRCDIR)),$(srcdir))
 SPIKE_SRC_GIT := $(SPIKE_SRCDIR)/.git
+PK_SRC_GIT := $(PK_SRCDIR)/.git
 else
 SPIKE_SRC_GIT :=
 endif
@@ -847,7 +848,7 @@ stamps/build-spike: $(SPIKE_SRCDIR) $(SPIKE_SRC_GIT)
 	mkdir -p $(dir $@)
 	date > $@
 
-stamps/build-pk32: $(PK_SRCDIR) stamps/build-gcc-newlib-stage2
+stamps/build-pk32: $(PK_SRCDIR) $(PK_SRC_GIT) stamps/build-gcc-newlib-stage2
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \
@@ -860,7 +861,7 @@ stamps/build-pk32: $(PK_SRCDIR) stamps/build-gcc-newlib-stage2
 	mkdir -p $(dir $@)
 	date > $@
 
-stamps/build-pk64: $(PK_SRCDIR) stamps/build-gcc-newlib-stage2
+stamps/build-pk64: $(PK_SRCDIR) $(PK_SRC_GIT) stamps/build-gcc-newlib-stage2
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \


### PR DESCRIPTION
Fix for:

* https://github.com/riscv-collab/riscv-gnu-toolchain/issues/1256

If using spike then ensure that git clone done for pk before configuring/building it.