### PR TITLE
Add github action ci to make-report using the spike simulator

### DIFF
--- a/.github/setup-apt.sh
+++ b/.github/setup-apt.sh
@@ -5,4 +5,5 @@ dpkg --add-architecture i386
 apt update
 apt install -y autoconf automake autotools-dev curl python3 libmpc-dev libmpfr-dev \
             libgmp-dev gawk build-essential bison flex texinfo gperf libtool \
-            patchutils bc zlib1g-dev libexpat-dev git ninja-build expect
+            patchutils bc zlib1g-dev libexpat-dev git ninja-build expect \
+            device-tree-compiler

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,6 +66,37 @@ jobs:
           name: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}
           path: riscv.tar.gz
 
+  test-sim:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:     [ubuntu-20.04]
+        mode:   [newlib, linux]
+        target: [rv64gc-lp64d]
+        sim:    [spike]
+        exclude:
+          - sim: spike
+            mode: linux
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: initialize submodules
+        run: |
+          git submodule init
+          git submodule update --recursive --progress --recommend-shallow
+
+      - name: install dependencies
+        run: sudo ./.github/setup-apt.sh
+
+      - name: build toolchain
+        run: |
+          TARGET_TUPLE=($(echo ${{ matrix.target }} | tr "-" "\n"))
+          ./configure --prefix=/opt/riscv --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]} --with-sim=${{ matrix.sim }}
+          make -j $(nproc) ${{ matrix.mode }}
+
+      - name: make report
+        run: make report-${{ matrix.mode }} -j $(nproc)
+
   build-multilib:
     if: ${{ false }} # Disable until multilib errors are triaged
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This adds a new CI job `test-sim` to run `make report-newlib` using `--with-sim=spike` on `rv64gc`. The CI job is set up with a matrix so we can easily add GDB simulator CI if there is interest.
The runtime of is roughly 2 hours and seems to be faster than the QEMU testsuite (So adding this won't slow down the overall CI).