### PR TITLE
Enable rv32gc make-report newlib and linux testing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,6 @@ jobs:
         if: |
           matrix.os == 'ubuntu-20.04'
           && (matrix.mode == 'linux' || matrix.mode == 'newlib')
-          && matrix.target == 'rv64gc-lp64d'
         run: |
           sudo make report-${{ matrix.mode }} -j $(nproc)
 


### PR DESCRIPTION
This enables the make-report step to run on rv32gc for linux and newlib.
The runtime is slightly faster than their rv64gc counterparts (So adding this won't slow down the overall CI).