### PR TITLE
Add LLVM to build CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,9 +16,14 @@ jobs:
         os:     [ubuntu-20.04, ubuntu-22.04]
         mode:   [newlib, linux, musl]
         target: [rv32gc-ilp32d, rv64gc-lp64d]
+        compiler: [gcc, llvm]
         exclude:
           - mode: musl
             target: rv32gc-ilp32d
+          - mode: newlib
+            compiler: llvm
+          - mode: musl
+            compiler: llvm
     steps:
       - uses: actions/checkout@v2
 
@@ -33,13 +38,19 @@ jobs:
       - name: build toolchain
         run: |
           TARGET_TUPLE=($(echo ${{ matrix.target }} | tr "-" "\n"))
-          ./configure --prefix=/opt/riscv --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]}
+          BUILD_TOOLCHAIN="./configure --prefix=/opt/riscv --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]}"
+          if [ "${{ matrix.compiler }}" == "llvm" ]; then # build toolchain with llvm
+            $BUILD_TOOLCHAIN --enable-llvm --enable-linux
+          else
+            $BUILD_TOOLCHAIN
+          fi
           sudo make -j $(nproc) ${{ matrix.mode }}
 
       - name: make report
         if: |
           matrix.os == 'ubuntu-20.04'
           && (matrix.mode == 'linux' || matrix.mode == 'newlib')
+          && matrix.compiler == 'gcc'
         run: |
           sudo make report-${{ matrix.mode }} -j $(nproc)
 
@@ -58,7 +69,7 @@ jobs:
             *)
               MODE="elf";;
           esac
-          echo ::set-output name=TOOLCHAIN_NAME::riscv$BITS-$MODE-${{ matrix.os }}-nightly
+          echo ::set-output name=TOOLCHAIN_NAME::riscv$BITS-$MODE-${{ matrix.os }}-${{ matrix.compiler }}-nightly
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -48,12 +48,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:     [ubuntu-20.04, ubuntu-22.04]
-        mode:   [newlib, linux, musl]
-        target: [rv32gc-ilp32d, rv64gc-lp64d]
+        os:       [ubuntu-20.04, ubuntu-22.04]
+        mode:     [newlib, linux, musl]
+        target:   [rv32gc-ilp32d, rv64gc-lp64d]
+        compiler: [gcc, llvm]
         exclude:
           - mode: musl
             target: rv32gc-ilp32d
+          - mode: newlib
+            compiler: llvm
+          - mode: musl
+            compiler: llvm
     steps:
       - uses: actions/checkout@v2
 
@@ -64,18 +69,17 @@ jobs:
 
       - name: install apt dependencies
         run: sudo ./.github/setup-apt.sh
-      
+
       - name: build toolchain
         run: |
           TARGET_TUPLE=($(echo ${{ matrix.target }} | tr "-" "\n"))
           BUILD_TOOLCHAIN="./configure --prefix=/opt/riscv --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]}"
-          if [ "${{ matrix.mode }}" == "linux" ]; then # build toolchain with llvm
+          if [ "${{ matrix.compiler }}" == "llvm" ]; then # build toolchain with llvm
             $BUILD_TOOLCHAIN --enable-llvm --enable-linux
-            sudo make -j $(nproc) all
           else
             $BUILD_TOOLCHAIN
-            sudo make -j $(nproc) ${{ matrix.mode }}
           fi
+          sudo make -j $(nproc) ${{ matrix.mode }}
 
       - name: build qemu
         if: "${{ matrix.mode }}" == "linux"


### PR DESCRIPTION
Currently no GCC-linux binaries are generated on the nightly CI run.
This PR also adds LLVM to the build workflow.

Related to: #1263