### PR TITLE
Add force flag when creating symbolic link for clang

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -938,7 +938,7 @@ stamps/build-llvm-linux: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) \
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	cp $(notdir $@)/lib/riscv$(XLEN)-unknown-linux-gnu/libc++* $(SYSROOT)/lib
-	cd $(INSTALL_DIR)/bin && ln -s clang $(LINUX_TUPLE)-clang
+	cd $(INSTALL_DIR)/bin && ln -s -f clang $(LINUX_TUPLE)-clang
 	mkdir -p $(dir $@) && touch $@
 
 stamps/build-llvm-newlib:


### PR DESCRIPTION
when incremental compiling, following error reported:
"ln: failed to create symbolic link 'riscv64-unknown-linux-gnu-clang': File exists" 

then make aborted.
add -f flag to solve this
