### PR TITLE
Generate seperate release names for LLVM and GCC toolchain release artifacts

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -101,7 +101,7 @@ jobs:
             *)
               MODE="elf";;
           esac
-          echo ::set-output name=TOOLCHAIN_NAME::riscv$BITS-$MODE-${{ matrix.os }}-nightly
+          echo ::set-output name=TOOLCHAIN_NAME::riscv$BITS-$MODE-${{ matrix.os }}-${{ matrix.compiler }}-nightly
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
In #1264, I changed the [name of the generated artifacts in build.yaml](https://github.com/riscv-collab/riscv-gnu-toolchain/pull/1264/files#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L61-R72), but missed the corresponding name in nightly-release.yaml.
This PR fixes that so the LLVM/GCC generated artifacts don't have a naming clash and overwrite eachother in the release flow.
