### PR TITLE
Remove source trees after CI build to recover disk space before packaging

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,11 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: initialize submodules
-        run: |
-          git submodule init
-          git submodule update --recursive --progress --recommend-shallow
-
       - name: install dependencies
         run: sudo ./.github/setup-apt.sh
 
@@ -51,6 +46,12 @@ jobs:
           && matrix.compiler == 'gcc'
         run: |
           sudo make report-${{ matrix.mode }} -j $(nproc)
+
+      - name: recover space
+        run: |
+          sudo du -hs / 2> /dev/null || true
+          sudo rm -rf binutils dejagnu gcc gdb glibc llvm musl newlib pk qemu spike || true
+          sudo du -hs / 2> /dev/null || true
 
       - name: tarball build
         run: tar czvf riscv.tar.gz -C /opt/ riscv/
@@ -88,11 +89,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: initialize submodules
-        run: |
-          git submodule init
-          git submodule update --recursive --progress --recommend-shallow
-
       - name: install dependencies
         run: sudo ./.github/setup-apt.sh
 
@@ -115,11 +111,6 @@ jobs:
         target: [rv64gc-lp64d]
     steps:
       - uses: actions/checkout@v2
-
-      - name: initialize submodules
-        run: |
-          git submodule init
-          git submodule update --recursive --progress --recommend-shallow
 
       - name: install dependencies
         run: sudo ./.github/setup-apt.sh

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -60,11 +60,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: initialize submodules
-        run: |
-          git submodule init
-          git submodule update --recursive --progress --recommend-shallow
-
       - name: install apt dependencies
         run: sudo ./.github/setup-apt.sh
 
@@ -83,6 +78,12 @@ jobs:
         if: ${{ matrix.mode }} == 'linux'
         run: |
           sudo make -j$(nproc) build-sim SIM=qemu
+
+      - name: recover space
+        run: |
+          sudo du -hs / 2> /dev/null || true
+          sudo rm -rf binutils dejagnu gcc gdb glibc llvm musl newlib pk qemu spike || true
+          sudo du -hs / 2> /dev/null || true
 
       - name: tarball build
         run: tar czvf riscv.tar.gz -C /opt/ riscv/


### PR DESCRIPTION
Also avoid initializing subdirectories to avoid cloning unused trees (llvm,gcc). With this change, source trees are pulled in on demand.

This fixes #1284.