### PR TITLE
Add --with-extra-multilib-test option

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -69,6 +69,8 @@ endif
 GLIBC_MULTILIB_NAMES := @glibc_multilib_names@
 GCC_CHECKING_FLAGS := @gcc_checking@
 
+EXTRA_MULTILIB_TEST := @extra_multilib_test@
+
 XLEN := $(shell echo $(WITH_ARCH) | tr A-Z a-z | sed 's/.*rv\([0-9]*\).*/\1/')
 ifneq ($(XLEN),32)
 	XLEN := 64
@@ -91,12 +93,12 @@ GDB_NATIVE_FLAGS := $(GDB_NATIVE_FLAGS_EXTRA)
 GLIBC_TARGET_FLAGS := $(GLIBC_TARGET_FLAGS_EXTRA)
 GLIBC_CC_FOR_TARGET ?= $(LINUX_TUPLE)-gcc
 GLIBC_CXX_FOR_TARGET ?= $(LINUX_TUPLE)-g++
-GLIBC_TARGET_BOARDS ?= $(shell echo "$(GLIBC_MULTILIB_NAMES)" | sed 's!\([_a-z0-9]*\)-\([_a-z0-9]*\)!riscv-sim/-march=\1/-mabi=\2/@cmodel@!g')
+GLIBC_TARGET_BOARDS ?= $(shell echo "$(GLIBC_MULTILIB_NAMES) $(EXTRA_MULTILIB_TEST)" | sed 's!\([_a-z0-9]*\)-\([_a-z0-9]*\)!riscv-sim/-march=\1/-mabi=\2/@cmodel@!g')
 
 NEWLIB_CC_FOR_TARGET ?= $(NEWLIB_TUPLE)-gcc
 NEWLIB_CXX_FOR_TARGET ?= $(NEWLIB_TUPLE)-g++
-NEWLIB_TARGET_BOARDS ?= $(shell echo "$(NEWLIB_MULTILIB_NAMES)" | sed 's!\([_a-z0-9]*\)-\([_a-z0-9]*\)!riscv-sim/-march=\1/-mabi=\2/@cmodel@!g')
-NEWLIB_NANO_TARGET_BOARDS ?= $(shell echo "$(NEWLIB_MULTILIB_NAMES)" | sed 's!\([_a-z0-9]*\)-\([_a-z0-9]*\)!riscv-sim-nano/-march=\1/-mabi=\2/@cmodel@!g')
+NEWLIB_TARGET_BOARDS ?= $(shell echo "$(NEWLIB_MULTILIB_NAMES) $(EXTRA_MULTILIB_TEST)" | sed 's!\([_a-z0-9]*\)-\([_a-z0-9]*\)!riscv-sim/-march=\1/-mabi=\2/@cmodel@!g')
+NEWLIB_NANO_TARGET_BOARDS ?= $(shell echo "$(NEWLIB_MULTILIB_NAMES) $(EXTRA_MULTILIB_TEST)" | sed 's!\([_a-z0-9]*\)-\([_a-z0-9]*\)!riscv-sim-nano/-march=\1/-mabi=\2/@cmodel@!g')
 NEWLIB_CC_FOR_MULTILIB_INFO := $(NEWLIB_CC_FOR_TARGET)
 
 MUSL_TARGET_FLAGS := $(MUSL_TARGET_FLAGS_EXTRA)

--- a/README.md
+++ b/README.md
@@ -246,6 +246,21 @@ The command below can be used to run the glibc tests:
 
     make check-glibc-linux
 
+##### Adding more arch/abi combination for testing without introducing multilib
+
+`--with-extra-multilib-test` can be used when you want to test more combination
+of arch/ABI, for example: built a linux toolchain with multilib with
+`rv64gc/lp64d` and `rv64imac/lp64`, but you want to test more configuration like
+`rv64gcv/lp64d` or `rv64gcv_zba/lp64d`, then you can use --with-extra-multilib-test
+to specify that via `--with-extra-multilib-test="rv64gcv-lp64d;rv64gcv_zba-lp64d"`,
+then the testing will run for `rv64gc/lp64d`, `rv64imac/lp64`, `rv64gcv/lp64d`
+and `rv64gcv_zba/lp64d`.
+
+`--with-extra-multilib-test` support bare-metal and linux toolchain and support
+even multilib is disable, but the user must ensure extra multilib test
+configuration can be work with existing lib/multilib, e.g. rv32gcv/ilp32 test
+can't work if multilib didn't have any rv32 multilib.
+
 ### LLVM / clang
 
 LLVM can be used in combination with the RISC-V GNU Compiler Toolchain

--- a/configure
+++ b/configure
@@ -614,6 +614,7 @@ musl_multilib_names
 newlib_multilib_names
 glibc_multilib_names
 multilib_flags
+extra_multilib_test
 multilib_gen
 WITH_SIM
 WITH_ISA_SPEC
@@ -689,6 +690,7 @@ with_isa_spec
 with_sim
 enable_multilib
 with_multilib_generator
+with_extra_multilib_test
 enable_gcc_checking
 with_cmodel
 with_target_cflags
@@ -1359,6 +1361,13 @@ Optional Packages:
                           Multi-libs configuration string, only supported for
                           bare-metal/elf toolchain, this option implied
                           --enable-multilib
+  --with-extra-multilib-test
+                          Adding extra multi-libs configuration for testing,
+                          this can be use even --disable-multilib, but be
+                          aware user need to make sure those extra multilib
+                          set can work/compatible with existing multi-libs,
+                          format: <arch>-<abi>;<arch>-<abi> e.g:
+                          --with-extra-multilib-test="rv64gcv-lp64;rv64gcv_zba-lp64"
   --with-cmodel           Select the code model to use when building libc and
                           libgcc [--with-cmodel=medlow]
   --with-target-cflags    Add extra target flags for C for library code
@@ -3417,6 +3426,16 @@ else
 fi
 
 
+
+# Check whether --with-extra-multilib-test was given.
+if test "${with_extra_multilib_test+set}" = set; then :
+  withval=$with_extra_multilib_test;
+else
+  with_extra_multilib_test=no
+
+fi
+
+
 if test "x$with_multilib_generator" != xno; then :
   multilib_gen="$with_multilib_generator"
 
@@ -3425,6 +3444,13 @@ else
 
 fi
 
+if test "x$with_extra_multilib_test" != xno; then :
+  extra_multilib_test="$with_extra_multilib_test"
+
+else
+  extra_multilib_test=""
+
+fi
 
 if test "x$enable_multilib" != xno || test "x$with_multilib_generator" != xno; then :
   multilib_flags=--enable-multilib

--- a/configure.ac
+++ b/configure.ac
@@ -135,10 +135,20 @@ AC_ARG_WITH(multilib-generator,
 	[with_multilib_generator=no]
 	)
 
+AC_ARG_WITH(extra-multilib-test,
+	[AS_HELP_STRING([--with-extra-multilib-test],
+		[Adding extra multi-libs configuration for testing, this can be use even --disable-multilib, but be aware user need to make sure those extra multilib set can work/compatible with existing multi-libs, format: <arch>-<abi>;<arch>-<abi>  e.g: --with-extra-multilib-test="rv64gcv-lp64;rv64gcv_zba-lp64"])],
+	[],
+	[with_extra_multilib_test=no]
+	)
+
 AS_IF([test "x$with_multilib_generator" != xno],
         [AC_SUBST(multilib_gen,"$with_multilib_generator")],
         [AC_SUBST(multilib_gen,"")])
 
+AS_IF([test "x$with_extra_multilib_test" != xno],
+        [AC_SUBST(extra_multilib_test,"$with_extra_multilib_test")],
+        [AC_SUBST(extra_multilib_test,"")])
 
 AS_IF([test "x$enable_multilib" != xno || test "x$with_multilib_generator" != xno],
         [AC_SUBST(multilib_flags,--enable-multilib)],


### PR DESCRIPTION
NOTE: This is toolchain developer facing feature.

This allow user to add extra testing multi-lib arch, it's useful when develop and/or testing new extensions.

Usage:

`--with-extra-multilib-test="arch-abi[;arch-abi]"`

e.g.

linux enable enabled multilib, so default will build with follwoing configuration:

```
lib32/ilp32;@march=rv32imac@mabi=ilp32
lib32/ilp32d;@march=rv32imafdc@mabi=ilp32d
lib64/lp64;@march=rv64imac@mabi=lp64
lib64/lp64d;@march=rv64imafdc@mabi=lp64d
```

But you want to testing more on vector stuffs like rv32gcv and rv64gcv, then you can configure with `--with-extra-multilib-test="rv32gcv-ilp32d;rv64gcv;lp64d"`

Then the testing will run `rv32imac-ilp32 rv32imafdc-ilp32d rv64imac-lp64 rv64imafdc-lp64d and rv32gcv-ilp32d;rv64gcv;lp64d`!

NOTE: Extra multilib test settings still require existing multilib has support those extra settings, e.g. you can't add rv32imafc_zbb-ilp32f on above example since no compatible multilib has provided.