### PR TITLE
Fix bug in configure.ac and regenerate configure

### DIFF
--- a/configure
+++ b/configure
@@ -587,11 +587,8 @@ LIBOBJS
 qemu_targets
 enable_libsanitizer
 with_linux_headers_src
+with_dejagnu_src
 with_llvm_src
-with_pk_src
-with_dejagnu_src
-with_pk_src
-with_dejagnu_src
 with_pk_src
 with_spike_src
 with_qemu_src
@@ -1334,7 +1331,6 @@ Optional Features:
                           [--disable-linux]
   --enable-debug-info     build glibc/musl/newlibc/libgcc with debug
                           information
-  --disable-debug-info    build glibc and musl without debug infromation
   --enable-multilib       build both RV32 and RV64 runtime libraries (only
                           RV64 for musl libc) [--disable-multilib]
   --enable-gcc-checking   Enable gcc internal checking, it will make gcc very
@@ -3303,9 +3299,16 @@ if test "${enable_debug_info+set}" = set; then :
   enableval=$enable_debug_info; enable_debug_info=yes
 else
   enable_debug_info=no
-  enableval=$enable_debug_info; disable_debug_info=yes
+
 fi
 
+
+if test "x$enable_debug_info" != xyes; then :
+  disable_debug_info=yes
+else
+  disable_debug_info=no
+
+fi
 
 if test "x$enable_debug_info" != xyes; then :
   debug_info=""
@@ -3782,25 +3785,6 @@ fi
 
 else
   with_llvm_src="\$(srcdir)/llvm"
-
-fi
-
-	}
-{
-
-# Check whether --with-dejagnu-src was given.
-if test "${with_dejagnu_src+set}" = set; then :
-  withval=$with_dejagnu_src;
-else
-  with_dejagnu_src=default
-
-fi
-
-	  if test "x$with_dejagnu_src" != xdefault; then :
-  with_dejagnu_src=$with_dejagnu_src
-
-else
-  with_dejagnu_src="\$(srcdir)/dejagnu"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,3 +1,4 @@
+## Process this file with autoconf 2.69. Other versions may not work.
 AC_INIT(riscv-toolchain, 1.0)
 
 AC_PROG_CC
@@ -58,8 +59,6 @@ AC_ARG_ENABLE(debug_info,
         )
 
 AS_IF([test "x$enable_debug_info" != xyes],
-        [AS_HELP_STRING([--disable-debug-info],
-		[build glibc and musl without debug infromation])],
         [disable_debug_info=yes],
         [disable_debug_info=no]
         )


### PR DESCRIPTION
	* configure: Regenerated.
	* configure.ac: Remove redundant AS_HELP_STRING when testing enable_debug_info; add comment to use Autoconf 2.69.