### PR TITLE
Specify vector spec v1.0 in QEMU arguments.

### DIFF
--- a/scripts/march-to-cpu-opt
+++ b/scripts/march-to-cpu-opt
@@ -12,7 +12,7 @@ EXT_OPTS = {
   "zbb":             "zbb=true",
   "zbc":             "zbc=true",
   "zbs":             "zbs=true",
-  "v":               "v=true",
+  "v":               "v=true,vext_spec=v1.0",
   "zve32f":          "Zve32f=true",
   "zve64f":          "Zve64f=true",
   "zfh":             "Zfh=true",


### PR DESCRIPTION
Some testcases in GCC's testsuite check stdout (tests with dg-output). Qemu will print "vector version is not specified, use the default value v1.0" if the vector spec is not specified which will cause those testcases to fail for vector targets.
This PR specifies `vect_spec=v1.0` which resolves those failures.