### PR TITLE
Remove unused frameworks to give CI more disk space

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,15 @@ jobs:
           - mode: musl
             compiler: llvm
     steps:
+      - name: Remove unneeded frameworks to recover disk space
+        run: |
+          echo "-- Before --"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          echo "-- After --"
+          df -h
+
       - uses: actions/checkout@v2
 
       - name: install dependencies
@@ -87,6 +96,15 @@ jobs:
           - sim: spike
             mode: linux
     steps:
+      - name: Remove unneeded frameworks to recover disk space
+        run: |
+          echo "-- Before --"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          echo "-- After --"
+          df -h
+
       - uses: actions/checkout@v2
 
       - name: install dependencies
@@ -110,6 +128,15 @@ jobs:
         mode:   [newlib, linux]
         target: [rv64gc-lp64d]
     steps:
+      - name: Remove unneeded frameworks to recover disk space
+        run: |
+          echo "-- Before --"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          echo "-- After --"
+          df -h
+
       - uses: actions/checkout@v2
 
       - name: install dependencies

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -58,6 +58,15 @@ jobs:
           - mode: musl
             compiler: llvm
     steps:
+      - name: Remove unneeded frameworks to recover disk space
+        run: |
+          echo "-- Before --"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          echo "-- After --"
+          df -h
+
       - uses: actions/checkout@v2
 
       - name: install apt dependencies


### PR DESCRIPTION
The LLVM build occasionally bumps up against the memory constraints.
This should give us ~12gb more to work with. 