### PR TITLE
Upgrade CI commands to resolve warnings

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,7 +79,7 @@ jobs:
           esac
           echo "TOOLCHAIN_NAME=riscv$BITS-$MODE-${{ matrix.os }}-${{ matrix.compiler }}-nightly" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}
           path: riscv.tar.gz
@@ -169,7 +169,7 @@ jobs:
           esac
           echo "TOOLCHAIN_NAME=riscv$BITS-$MODE-${{ matrix.os }}-multilib-nightly" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}
           path: riscv.tar.gz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
           echo "-- After --"
           df -h
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: install dependencies
         run: sudo ./.github/setup-apt.sh
@@ -105,7 +105,7 @@ jobs:
           echo "-- After --"
           df -h
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: install dependencies
         run: sudo ./.github/setup-apt.sh
@@ -137,7 +137,7 @@ jobs:
           echo "-- After --"
           df -h
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: install dependencies
         run: sudo ./.github/setup-apt.sh

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,7 +77,7 @@ jobs:
             *)
               MODE="elf";;
           esac
-          echo ::set-output name=TOOLCHAIN_NAME::riscv$BITS-$MODE-${{ matrix.os }}-${{ matrix.compiler }}-nightly
+          echo "TOOLCHAIN_NAME=riscv$BITS-$MODE-${{ matrix.os }}-${{ matrix.compiler }}-nightly" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v2
         with:
@@ -167,7 +167,7 @@ jobs:
             *)
               MODE="elf";;
           esac
-          echo ::set-output name=TOOLCHAIN_NAME::riscv$BITS-$MODE-${{ matrix.os }}-multilib-nightly
+          echo "TOOLCHAIN_NAME=riscv$BITS-$MODE-${{ matrix.os }}-multilib-nightly" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -111,7 +111,7 @@ jobs:
           esac
           echo "TOOLCHAIN_NAME=riscv$BITS-$MODE-${{ matrix.os }}-${{ matrix.compiler }}-nightly" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}
           path: riscv.tar.gz

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -35,7 +35,7 @@ jobs:
               fi
           fi
           echo "::set-output name=stale::$STALE"
-          
+
           if [ "$STALE" == "true" ]; then
             exit 1
           fi
@@ -67,7 +67,7 @@ jobs:
           echo "-- After --"
           df -h
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: install apt dependencies
         run: sudo ./.github/setup-apt.sh
@@ -181,7 +181,7 @@ jobs:
                   file: .[1],
                   extension: .[2]
                 }
-              ] 
+              ]
             }'
           )
 

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -34,7 +34,7 @@ jobs:
                 STALE=true
               fi
           fi
-          echo "::set-output name=stale::$STALE"
+          echo "stale=$STALE" >> $GITHUB_OUTPUT
 
           if [ "$STALE" == "true" ]; then
             exit 1
@@ -109,7 +109,7 @@ jobs:
             *)
               MODE="elf";;
           esac
-          echo ::set-output name=TOOLCHAIN_NAME::riscv$BITS-$MODE-${{ matrix.os }}-${{ matrix.compiler }}-nightly
+          echo "TOOLCHAIN_NAME=riscv$BITS-$MODE-${{ matrix.os }}-${{ matrix.compiler }}-nightly" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v2
         with:
@@ -185,7 +185,7 @@ jobs:
             }'
           )
 
-          echo "::set-output name=asset_matrix::${ASSET_MATRIX}"
+          echo "asset_matrix=${ASSET_MATRIX}" >> $GITHUB_OUTPUT
         shell: bash
 
 


### PR DESCRIPTION
There are a large number of warnings in the CI. This PR resolves those warnings by upgrading/removing deprecated CI commands.

Resolved warnings:
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/