### PR TITLE
Bump QEMU to v8.1.0

### DIFF
--- a/test/allowlist/gcc/newlib.log
+++ b/test/allowlist/gcc/newlib.log
@@ -17,3 +17,20 @@ FAIL: g++.dg/abi/pure-virtual1.C
 # with `-Wall`
 #
 FAIL: g++.dg/warn/Wstringop-overflow-6.C
+
+#
+# Fixed with https://github.com/gcc-mirror/gcc/commit/fba0f47e4617e164716d3bce587fc6948088e225
+#
+FAIL: gcc.c-torture/execute/20000822-1.c
+FAIL: gcc.c-torture/execute/931002-1.c
+FAIL: gcc.c-torture/execute/921215-1.c
+FAIL: gcc.c-torture/execute/nestfunc-1.c
+FAIL: gcc.c-torture/execute/nestfunc-2.c
+FAIL: gcc.c-torture/execute/nestfunc-3.c
+FAIL: gcc.c-torture/execute/nestfunc-5.c
+FAIL: gcc.c-torture/execute/nestfunc-6.c
+FAIL: gcc.dg/trampoline-1.c
+FAIL: gcc.dg/torture/pr86389.c
+FAIL: gcc.dg/torture/stackalign/nested-5.c
+FAIL: gcc.dg/torture/stackalign/nested-6.c
+FAIL: gcc.dg/tree-ssa/tailcall-7-run.c


### PR DESCRIPTION
QEMU v7.1.0 has an [issue with some vector instructions](https://gitlab.com/qemu-project/qemu/-/issues/1441). This manifests in the (trunk) GCC testsuite with failures like this:
```
qemu-riscv64: ../../qemu/target/riscv/translate.c:211: decode_save_opc: Assertion `ctx->insn_start != NULL' failed.
/scratch/tc-testing/colab-trunk/build-rv64gcv/../scripts/wrapper/qemu/riscv64-unknown-linux-gnu-run: line 15: 267862 Segmentation fault      (core dumped) QEMU_CPU="$(march-to-cpu-opt --get-riscv-tag $1)" qemu-riscv$xlen -r 5.10 "${qemu_args[@]}" -L ${RISC_V_SYSROOT} "$@"
FAIL: gcc.target/riscv/rvv/autovec/gather-scatter/scatter_store_run-3.c execution test
```

Bumping to v8.1.0 resolves these failures.