### PR TITLE
Bump binutils to v2.41

### DIFF
--- a/test/allowlist/binutils/glibc.log
+++ b/test/allowlist/binutils/glibc.log
@@ -1,9 +1,1 @@
 #
-# Missing a relaxation to convert PC-relative GOT references to
-# local symbols to PC-relative direct references.needs a new 
-# relaxation and maybe a new relocation to eliminate tprel 
-# relocations in pie mode.
-#
-# This is an optimization, not a correctness issue.
-#
-FAIL: Build pr22263-1


### PR DESCRIPTION
Tested using `make report-binutils-linux` and `make report-binutils-newlib` and updated the allowlists to remove glibc failures that were fixed. The newlib failures did not change.

Also tested using `make report-newlib` and `make report-linux` with the default configuration.