### PR TITLE
Bump binutils to v2.41 release

### DIFF
--- a/test/allowlist/binutils/common.log
+++ b/test/allowlist/binutils/common.log
@@ -1,1 +1,12 @@
 #
+# Failures look like:
+# Error: rv64im_zba_zbb_zcb: unknown prefixed ISA extension `zcb'
+# Error: rv32i_zcf: unknown prefixed ISA extension `zcf'
+#
+FAIL: gas/riscv/march-fail-rv64i_zcf
+FAIL: gas/riscv/march-imply-zcd
+FAIL: gas/riscv/march-imply-zcf
+FAIL: gas/riscv/zca
+FAIL: gas/riscv/zcb
+FAIL: gas/riscv/zcd
+FAIL: gas/riscv/zcf


### PR DESCRIPTION
@vineetgarc pointed out that the binutils 2.41 actually has [2 release tags](https://github.com/riscv-collab/riscv-gnu-toolchain/commit/12143b6d2f00c910269d156cfa43433b2fc26481#commitcomment-128864616). This PR updates binutils to the [official 2.41 release](https://github.com/bminor/binutils-gdb/releases/tag/binutils-2_41-release).

Tested using `make report-binutils-linux` and `make report-binutils-newlib`

There are new failures.