### PR TITLE
gitmodules: Drop dejagnu tracking branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 [submodule "dejagnu"]
 	path = dejagnu
 	url = https://git.savannah.gnu.org/git/dejagnu.git
-	branch = dejagnu-1.6.3
+	branch = master
 [submodule "newlib"]
 	path = newlib
 	url = https://sourceware.org/git/newlib-cygwin.git


### PR DESCRIPTION
We recently moved Dejagnu to the upstream master branch's top commit. Therefore there is no need to set a tracking branch to 'dejagnu-1.6.3'.