### PR TITLE
Bump LLVM to 17.0.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,4 +39,4 @@
 [submodule "llvm"]
 	path = llvm
 	url = https://github.com/llvm/llvm-project.git
-	branch = release/15.x
+	branch = release/17.x


### PR DESCRIPTION
This commit bumps LLVM from 16.0.5 to 17.0.2.

Build succeeds on my Fedora 38 machine.
Also a smoke-test (building and executing a hello-world in C++) showed no issues.