### PR TITLE
Bump glibc to 2.38

### DIFF
--- a/test/allowlist/gcc/glibc.log
+++ b/test/allowlist/gcc/glibc.log
@@ -17,3 +17,9 @@ FAIL: gfortran.dg/ieee/rounding_3.f90
 # Synchronization problem.
 #
 FAIL: gcc.dg/tree-prof/time-profiler-2.c
+#
+# Fix upstream
+# https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=c9a19621a07e246385ae075b61283140b23c3b5a
+#
+FAIL: gcc.dg/analyzer/data-model-4.c
+FAIL: gcc.dg/analyzer/torture/conftest-1.c


### PR DESCRIPTION
This commit bumps glibc from 2.37 to 2.38.

I see the following regressions:
```
                === gcc: Unexpected fails for rv32imac ilp32 medlow ===                                                                                                                                                                       
FAIL: gcc.dg/analyzer/data-model-4.c (test for excess errors)                                                                                                                                                                                 
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O0  (test for excess errors)                                                                                                                                                                    
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O1  (test for excess errors)                                                                                                                                                                    
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O2  (test for excess errors)                                                                                                                                                                    
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)                                                                                                                  
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O3 -g  (test for excess errors)                                                                                                                                                                 
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -Os  (test for excess errors)                                                                                                                                                                    
                === gcc: Unexpected fails for rv32imafdc ilp32d medlow ===                                                                                                                                                                    
FAIL: gcc.dg/analyzer/data-model-4.c (test for excess errors)                                                                                                                                                                                 
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O0  (test for excess errors)                                                                                                                                                                    
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O1  (test for excess errors)                                                                                                                                                                    
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O2  (test for excess errors)                                                                                                                                                                    
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)                                                                                                                  
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O3 -g  (test for excess errors)                                                                                                                                                                 
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -Os  (test for excess errors)                                                                                                                                                                    
                === gcc: Unexpected fails for rv64imac lp64 medlow ===                                                                                                                                                                        
FAIL: gcc.dg/analyzer/data-model-4.c (test for excess errors)                                                                                                                                                                                 
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O0  (test for excess errors)                                                                                                                                                                    
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O1  (test for excess errors)
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O2  (test for excess errors)
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O3 -g  (test for excess errors)
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -Os  (test for excess errors)
                === gcc: Unexpected fails for rv64imafdc lp64d medlow ===
FAIL: gcc.dg/analyzer/data-model-4.c (test for excess errors)
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O0  (test for excess errors)
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O1  (test for excess errors)
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O2  (test for excess errors)
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O3 -g  (test for excess errors)
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -Os  (test for excess errors)
                                                           
               ========= Summary of gcc testsuite =========       
                            | # of unexpected case / # of unique unexpected case
                            |          gcc |          g++ |     gfortran |
   rv32imac/  ilp32/ medlow |    7 /     2 |    0 /     0 |    0 /     0 |
 rv32imafdc/ ilp32d/ medlow |    7 /     2 |    0 /     0 |    0 /     0 |
   rv64imac/   lp64/ medlow |    7 /     2 |    0 /     0 |    0 /     0 |
 rv64imafdc/  lp64d/ medlow |    7 /     2 |    0 /     0 |    0 /     0 |
```

The `conftest-1.c` error looks like this:
```
Executing on host: /home/cm/src/riscv-gnu-toolchain/glibc-2.38/build-gcc-linux-stage2/gcc/xgcc -B/home/cm/src/riscv-gnu-toolchain/glibc-2.38/build-gcc-linux-stage2/gcc/  /home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/torture/conftest-1.c  -march=rv32imac -mabi=ilp32 -mcmodel=medlow   -fdiagnostics-plain-output    -O0  -fanalyzer -fdiagnostics-path-format=separate-events -Wanalyzer-too-complex -fanalyzer-call-summaries -S   -o conftest-1.s    (timeout = 600)
spawn -ignore SIGHUP /home/cm/src/riscv-gnu-toolchain/glibc-2.38/build-gcc-linux-stage2/gcc/xgcc -B/home/cm/src/riscv-gnu-toolchain/glibc-2.38/build-gcc-linux-stage2/gcc/ /home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/torture/conftest-1.c -march=rv32imac -mabi=ilp32 -mcmodel=medlow -fdiagnostics-plain-output -O0 -fanalyzer -fdiagnostics-path-format=separate-events -Wanalyzer-too-complex -fanalyzer-call-summaries -S -o conftest-1.s
/home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/torture/conftest-1.c: In function 'main':
/home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/torture/conftest-1.c:6:24: warning: use of possibly-NULL 'f' where non-null expected [CWE-690] [-Wanalyzer-possible-null-argument]
/home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/torture/conftest-1.c:5:13: note: (1) this call could return NULL
/home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/torture/conftest-1.c:6:21: note: (2) following 'false' branch...
/home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/torture/conftest-1.c:6:24: note: (3) ...to here
/home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/torture/conftest-1.c:6:24: note: (4) argument 1 ('f') from (1) could be NULL where non-null expected
In file included from /home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/torture/conftest-1.c:1:
/opt/glibc-2.38/sysroot/usr/include/stdio.h:183:12: note: argument 1 of 'fclose' must be non-null
FAIL: gcc.dg/analyzer/torture/conftest-1.c   -O0  (test for excess errors)
Excess errors:
/home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/torture/conftest-1.c:6:24: warning: use of possibly-NULL 'f' where non-null expected [CWE-690] [-Wanalyzer-possible-null-argument]
```

Same issue with the `data-model-4.c` test:
```
Executing on host: /home/cm/src/riscv-gnu-toolchain/glibc-2.38/build-gcc-linux-stage2/gcc/xgcc -B/home/cm/src/riscv-gnu-toolchain/glibc-2.38/build-gcc-linux-stage2/gcc/  /home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/data-model-4.c  -march=rv32imafdc -mabi=ilp32d -mcmodel=medlow   -fdiagnostics-plain-output   -fanalyzer -Wanalyzer-too-complex -fanalyzer-call-summaries -fexceptions -S   -o data-model-4.s    (timeout = 600)
spawn -ignore SIGHUP /home/cm/src/riscv-gnu-toolchain/glibc-2.38/build-gcc-linux-stage2/gcc/xgcc -B/home/cm/src/riscv-gnu-toolchain/glibc-2.38/build-gcc-linux-stage2/gcc/ /home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/data-model-4.c -march=rv32imafdc -mabi=ilp32d -mcmodel=medlow -fdiagnostics-plain-output -fanalyzer -Wanalyzer-too-complex -fanalyzer-call-summaries -fexceptions -S -o data-model-4.s
/home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/data-model-4.c: In function 'main':
/home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/data-model-4.c:11:24: warning: use of possibly-NULL 'f' where non-null expected [CWE-690] [-Wanalyzer-possible-null-argument]
/home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/data-model-4.c:10:13: note: (1) this call could return NULL 
/home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/data-model-4.c:11:21: note: (2) following 'false' branch...
/home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/data-model-4.c:11:24: note: (3) ...to here 
/home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/data-model-4.c:11:24: note: (4) argument 1 ('f') from (1) could be NULL where non-null expected
In file included from /home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/data-model-4.c:6:
/opt/glibc-2.38/sysroot/usr/include/stdio.h:183:12: note: argument 1 of 'fclose' must be non-null
FAIL: gcc.dg/analyzer/data-model-4.c (test for excess errors)
Excess errors:
/home/cm/src/riscv-gnu-toolchain/glibc-2.38/gcc/gcc/testsuite/gcc.dg/analyzer/data-model-4.c:11:24: warning: use of possibly-NULL 'f' where non-null expected [CWE-690] [-Wanalyzer-possible-null-argument]
```

These issues are not RISC-V-specific. So most likely they are already fixed.
If someone has some ideas, then let me know.
If we find the fix upstream (or in the GCC 13 release branch), we can put those tests on the allow-list and merge this PR.