### PR TITLE
Fix for issue #1351 - remove redundant 'linux' from matrix and remove unnecessary 'exclude' section

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,12 +89,9 @@ jobs:
     strategy:
       matrix:
         os:     [ubuntu-20.04]
-        mode:   [newlib, linux]
+        mode:   [newlib]
         target: [rv64gc-lp64d]
         sim:    [spike]
-        exclude:
-          - sim: spike
-            mode: linux
     steps:
       - name: Remove unneeded frameworks to recover disk space
         run: |


### PR DESCRIPTION
Fix for issue #1351 - remove redundant 'linux' from matrix and remove unnecessary 'exclude' section.

* https://github.com/riscv-collab/riscv-gnu-toolchain/issues/1351