### PR TITLE
Switch from Ubuntu 20.04 LTS to 22.04 LTS for jobs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,12 +89,9 @@ jobs:
     strategy:
       matrix:
         os:     [ubuntu-22.04]
-        mode:   [newlib, linux]
+        mode:   [newlib]
         target: [rv64gc-lp64d]
         sim:    [spike]
-        exclude:
-          - sim: spike
-            mode: linux
     steps:
       - name: Remove unneeded frameworks to recover disk space
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: make report
         if: |
-          matrix.os == 'ubuntu-20.04'
+          matrix.os == 'ubuntu-22.04'
           && (matrix.mode == 'linux' || matrix.mode == 'newlib')
           && matrix.compiler == 'gcc'
         run: |
@@ -88,7 +88,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:     [ubuntu-20.04]
+        os:     [ubuntu-22.04]
         mode:   [newlib, linux]
         target: [rv64gc-lp64d]
         sim:    [spike]
@@ -124,7 +124,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:     [ubuntu-20.04]
+        os:     [ubuntu-22.04]
         mode:   [newlib, linux]
         target: [rv64gc-lp64d]
     steps:


### PR DESCRIPTION
See here:

* https://github.com/riscv-collab/riscv-gnu-toolchain/issues/1351#issuecomment-1764355802

Switch from Ubuntu 20.04 LTS to 22.04 LTS for jobs `build` (`make report` step), `test-sim` and `build-multilib`.

Note that `build-multilib` is disabled by default so would need to be temporarily enabled in order to validate this change:

* https://github.com/riscv-collab/riscv-gnu-toolchain/blob/6b1324367b879a9b89437846827b48151b26b412/.github/workflows/build.yaml#L123