### PR TITLE
prevent multilib reports from failing with trailing ; in configure

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -63,7 +63,7 @@ ifeq ($(MULTILIB_GEN),)
 NEWLIB_MULTILIB_NAMES := @newlib_multilib_names@
 GCC_MULTILIB_FLAGS := $(MULTILIB_FLAGS)
 else
-NEWLIB_MULTILIB_NAMES := $(shell echo "$(MULTILIB_GEN)" | $(SED) 's/;/\n/g'| $(AWK) '{split($$0,a,"-"); printf "%s-%s ", a[1],a[2]}')
+NEWLIB_MULTILIB_NAMES := $(shell echo "$(MULTILIB_GEN)" | $(SED) 's/;/\n/g' | $(SED) '/^$$/d' | $(AWK) '{split($$0,a,"-"); printf "%s-%s ", a[1],a[2]}')
 GCC_MULTILIB_FLAGS := $(MULTILIB_FLAGS) --with-multilib-generator="$(MULTILIB_GEN)"
 endif
 GLIBC_MULTILIB_NAMES := @glibc_multilib_names@


### PR DESCRIPTION
Currently testsuite runs with trailing `;` when making the `--with-multilib-generator` string will error right before reporting results as shown below. 
```                === g++ Summary for riscv-sim/-march=rv32gc/-mabi=ilp32d/-mcmodel=medlow ===

# of expected passes            4874
# of expected failures          21
# of unsupported tests          305
Running target riscv-sim/-march=/-mabi=/-mcmodel=medlow
Using /scratch/ewlu/ci/riscv-collab/build/share/dejagnu/baseboards/riscv-sim.exp as board description file for target.
Using /scratch/ewlu/ci/riscv-collab/build/share/dejagnu/config/sim.exp as generic interface file for target.
Using /scratch/ewlu/ci/riscv-collab/build/share/dejagnu/baseboards/basic-sim.exp as board description file for target.
ERROR: tcl error sourcing board description file for target /scratch/ewlu/ci/riscv-collab/build/share/dejagnu/baseboards/riscv-sim.exp.
.
xgcc: error: missing argument to '-march='
xgcc: error: missing argument to '-mabi='
.
xgcc: error: missing argument to '-march='
xgcc: error: missing argument to '-mabi='
    while executing
"exec /scratch/ewlu/ci/riscv-collab/build/build-gcc-newlib-stage2/gcc/xgcc --print-multi-directory -march= -mabi= -mcmodel=medlow"
    ("eval" body line 1)
    invoked from within
"eval exec $compiler --print-multi-directory $mopts"
    (procedure "get_multilibs" line 121)
    invoked from within
"get_multilibs"
    (procedure "newlib_include_flags" line 12)
    invoked from within
"newlib_include_flags"
    (file "/scratch/ewlu/ci/riscv-collab/build/share/dejagnu/baseboards/riscv-sim.exp" line 38)
    invoked from within
"source /scratch/ewlu/ci/riscv-collab/build/share/dejagnu/baseboards/riscv-sim.exp"
    ("uplevel" body line 1)
    invoked from within
"uplevel #0 source /scratch/ewlu/ci/riscv-collab/build/share/dejagnu/baseboards/riscv-sim.exp"
    invoked from within
"catch "uplevel #0 source $filename" error"
make[3]: Leaving directory '/scratch/ewlu/ci/riscv-collab/build/build-gcc-newlib-stage2/gcc'
testsuite/g++/g++.sum.sep: no recognised summary line
testsuite/g++/g++.log.sep: saw test result before harness name
make[2]: Leaving directory '/scratch/ewlu/ci/riscv-collab/build/build-gcc-newlib-stage2/gcc'
make[1]: Leaving directory '/scratch/ewlu/ci/riscv-collab/build/build-gcc-newlib-stage2'
mkdir -p stamps/
date > stamps/check-gcc-newlib
/scratch/ewlu/ci/riscv-collab/build/../scripts/testsuite-filter gcc newlib /scratch/ewlu/ci/riscv-collab/build/../test/allowlist `find build-gcc-newlib-stage2/gcc/testsuite/ -name *.sum |paste -sd "," -`

               ========= Summary of gcc testsuite =========
                            | # of unexpected case / # of unique unexpected case
                            |          gcc |          g++ |     gfortran |
make: *** [Makefile:1057: report-gcc-newlib] Error 1
ewlu@ewlu:/scratch/ewlu/ci/riscv-collab/build$ head config.log
This file contains any messages produced by compilers while
running configure, to aid debugging if configure makes a mistake.

It was created by riscv-toolchain configure 1.0, which was
generated by GNU Autoconf 2.69.  Invocation command line was

  $ ../configure --prefix=/scratch/ewlu/ci/riscv-collab/build --with-multilib-generator=rv32gc-ilp32d--;

## --------- ##
## Platform. ##
```
Using `--with-multilib-generator="rv32gc-ilp32d--"` would not error and display the testsuite results. Add additional `sed` pass to remove empty march and mabi from being passed in.

Before:
```
$ echo "rv32gc-ilp32d--;" | sed 's/;/\n/g' | awk '{split($$0,a,"-"); printf "%s-%s ", a[1],a[2]}'
rv32gc-ilp32d -
```
After:
```
$ echo "rv32gc-ilp32d--;" | sed 's/;/\n/g' | sed '/^$/d' | awk '{split($$0,a,"-"); printf "%s-%s ", a[1],a[2]}'
rv32gc-ilp32d
```