### PR TITLE
Extend semantic for option '--with-extra-multilib-test'

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -93,12 +93,25 @@ GDB_NATIVE_FLAGS := $(GDB_NATIVE_FLAGS_EXTRA)
 GLIBC_TARGET_FLAGS := $(GLIBC_TARGET_FLAGS_EXTRA)
 GLIBC_CC_FOR_TARGET ?= $(LINUX_TUPLE)-gcc
 GLIBC_CXX_FOR_TARGET ?= $(LINUX_TUPLE)-g++
-GLIBC_TARGET_BOARDS ?= $(shell echo "$(GLIBC_MULTILIB_NAMES) $(EXTRA_MULTILIB_TEST)" | sed 's!\([_a-z0-9]*\)-\([_a-z0-9]*\)!riscv-sim/-march=\1/-mabi=\2/@cmodel@!g')
+GLIBC_TARGET_BOARDS ?= $(shell set -x && $(srcdir)/scripts/generate_target_board \
+  --sim-name riscv-sim \
+  --cmodel $(shell echo @cmodel@ | cut -d '=' -f2) \
+  --build-arch-abi $(GLIBC_MULTILIB_NAMES) \
+  --extra-test-arch-abi-flags-list $(subst ;,\;,$(EXTRA_MULTILIB_TEST)))
 
 NEWLIB_CC_FOR_TARGET ?= $(NEWLIB_TUPLE)-gcc
 NEWLIB_CXX_FOR_TARGET ?= $(NEWLIB_TUPLE)-g++
-NEWLIB_TARGET_BOARDS ?= $(shell echo "$(NEWLIB_MULTILIB_NAMES) $(EXTRA_MULTILIB_TEST)" | sed 's!\([_a-z0-9]*\)-\([_a-z0-9]*\)!riscv-sim/-march=\1/-mabi=\2/@cmodel@!g')
-NEWLIB_NANO_TARGET_BOARDS ?= $(shell echo "$(NEWLIB_MULTILIB_NAMES) $(EXTRA_MULTILIB_TEST)" | sed 's!\([_a-z0-9]*\)-\([_a-z0-9]*\)!riscv-sim-nano/-march=\1/-mabi=\2/@cmodel@!g')
+NEWLIB_TARGET_BOARDS ?= $(shell set -x && $(srcdir)/scripts/generate_target_board \
+  --sim-name riscv-sim \
+  --cmodel $(shell echo @cmodel@ | cut -d '=' -f2) \
+  --build-arch-abi $(NEWLIB_MULTILIB_NAMES) \
+  --extra-test-arch-abi-flags-list $(subst ;,\;,$(EXTRA_MULTILIB_TEST)))
+
+NEWLIB_NANO_TARGET_BOARDS ?= $(shell set -x && $(srcdir)/scripts/generate_target_board \
+  --sim-name riscv-sim-nano \
+  --cmodel $(shell echo @cmodel@ | cut -d '=' -f2) \
+  --build-arch-abi $(NEWLIB_MULTILIB_NAMES) \
+  --extra-test-arch-abi-flags-list $(subst ;,\;,$(EXTRA_MULTILIB_TEST)))
 NEWLIB_CC_FOR_MULTILIB_INFO := $(NEWLIB_CC_FOR_TARGET)
 
 MUSL_TARGET_FLAGS := $(MUSL_TARGET_FLAGS_EXTRA)

--- a/Makefile.in
+++ b/Makefile.in
@@ -93,25 +93,25 @@ GDB_NATIVE_FLAGS := $(GDB_NATIVE_FLAGS_EXTRA)
 GLIBC_TARGET_FLAGS := $(GLIBC_TARGET_FLAGS_EXTRA)
 GLIBC_CC_FOR_TARGET ?= $(LINUX_TUPLE)-gcc
 GLIBC_CXX_FOR_TARGET ?= $(LINUX_TUPLE)-g++
-GLIBC_TARGET_BOARDS ?= $(shell set -x && $(srcdir)/scripts/generate_target_board \
+GLIBC_TARGET_BOARDS ?= $(shell $(srcdir)/scripts/generate_target_board \
   --sim-name riscv-sim \
   --cmodel $(shell echo @cmodel@ | cut -d '=' -f2) \
   --build-arch-abi $(GLIBC_MULTILIB_NAMES) \
-  --extra-test-arch-abi-flags-list $(subst ;,\;,$(EXTRA_MULTILIB_TEST)))
+  --extra-test-arch-abi-flags-list "$(subst ;,\;,$(EXTRA_MULTILIB_TEST))")
 
 NEWLIB_CC_FOR_TARGET ?= $(NEWLIB_TUPLE)-gcc
 NEWLIB_CXX_FOR_TARGET ?= $(NEWLIB_TUPLE)-g++
-NEWLIB_TARGET_BOARDS ?= $(shell set -x && $(srcdir)/scripts/generate_target_board \
+NEWLIB_TARGET_BOARDS ?= $(shell $(srcdir)/scripts/generate_target_board \
   --sim-name riscv-sim \
   --cmodel $(shell echo @cmodel@ | cut -d '=' -f2) \
   --build-arch-abi $(NEWLIB_MULTILIB_NAMES) \
-  --extra-test-arch-abi-flags-list $(subst ;,\;,$(EXTRA_MULTILIB_TEST)))
+  --extra-test-arch-abi-flags-list "$(subst ;,\;,$(EXTRA_MULTILIB_TEST))")
 
-NEWLIB_NANO_TARGET_BOARDS ?= $(shell set -x && $(srcdir)/scripts/generate_target_board \
+NEWLIB_NANO_TARGET_BOARDS ?= $(shell $(srcdir)/scripts/generate_target_board \
   --sim-name riscv-sim-nano \
   --cmodel $(shell echo @cmodel@ | cut -d '=' -f2) \
   --build-arch-abi $(NEWLIB_MULTILIB_NAMES) \
-  --extra-test-arch-abi-flags-list $(subst ;,\;,$(EXTRA_MULTILIB_TEST)))
+  --extra-test-arch-abi-flags-list "$(subst ;,\;,$(EXTRA_MULTILIB_TEST))")
 NEWLIB_CC_FOR_MULTILIB_INFO := $(NEWLIB_CC_FOR_TARGET)
 
 MUSL_TARGET_FLAGS := $(MUSL_TARGET_FLAGS_EXTRA)

--- a/README.md
+++ b/README.md
@@ -261,6 +261,15 @@ even multilib is disable, but the user must ensure extra multilib test
 configuration can be work with existing lib/multilib, e.g. rv32gcv/ilp32 test
 can't work if multilib didn't have any rv32 multilib.
 
+`--with-extra-multilib-test` also allow you append additional build flags after
+the arch/ABI, for example: built a linux toolchain with `rv64gc/lp64d`, and you
+can test more configuration like `rv64gcv/lp64d` with one additional build config
+`--param=riscv-autovec-lmul=dynamic`, then you can use --with-extra-multilib-test
+to specify that via
+`--with-extra-multilib-test="rv64gcv-lp64d:--param=riscv-autovec-lmul=dynamic"`.
+Then the testing will build the run test with option `--param=riscv-autovec-lmul=dynamic`
+before run the `rv64gcv-lp64d` test.
+
 ### LLVM / clang
 
 LLVM can be used in combination with the RISC-V GNU Compiler Toolchain

--- a/scripts/generate_target_board
+++ b/scripts/generate_target_board
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+
+def parse_options(argv):
+  parser = argparse.ArgumentParser()
+
+  parser.add_argument('--sim-name', type = str, required = True,
+                      help = 'The sim name of target board, like riscv-sim.')
+  parser.add_argument('--build-arch-abi', type = str, required = True,
+                      help = 'The arch and abi when build, like ' +
+                             '--with-arch=rv64gcv --with-abi=lp64d' +
+                             'in riscv-gnu-toolchain configure, ' +
+                             'within format rv64gcv-lp64d.')
+  parser.add_argument('--extra-test-arch-abi-flags-list', type=str,
+                      help = 'The arch, abi and flags list for extra test,' +
+                             'like =rv64gcv_zvl256b-lp64d:' +
+                             '--param=riscv-autovec-lmul=dynamic:' +
+                             '--param=riscv-autovec-preference=fixed-vlmax.',
+                      default = '')
+  parser.add_argument('--cmodel', type = str, default = 'medlow',
+                      help = 'The name of the cmodel, like medlow.')
+
+  options = parser.parse_args()
+  return options
+
+# Generate only one target board like below:
+#   riscv-sim/-march=rv64gcv_zvl256b/-mabi=lp64d/-mcmodel=medlow
+# From the config_string like below, --param is optional
+#   rv64gcv_zvl128b-lp64d:--param=riscv-autovec-lmul=m1
+def generate_one_target_board(config_string, options):
+  configs = config_string.split(":")
+  arch_and_abi = configs[0].split("-")
+  arch = arch_and_abi[0]
+  abi = arch_and_abi[1]
+
+  if len (configs) == 1:
+    return "{0}/-march={1}/-mabi={2}/-mcmodel={3}".format(
+      options.sim_name, arch, abi, options.cmodel)
+
+  flags = '/'.join(configs[1:])
+
+  return "{0}/-march={1}/-mabi={2}/-mcmodel={3}/{4}".format(
+    options.sim_name, arch, abi, options.cmodel, flags)
+
+def main(argv):
+  options = parse_options(argv)
+
+  if not options.sim_name or not options.build_arch_abi:
+    print ("The --sim-name and/or --build-arch-abi cannot be empty or null.")
+    return
+
+  target_board_list = [
+    generate_one_target_board(options.build_arch_abi, options)
+  ]
+
+  if options.extra_test_arch_abi_flags_list:
+    extra_test_list = options.extra_test_arch_abi_flags_list.split (";")
+
+    for extra_test in extra_test_list:
+      target_board_list.append(generate_one_target_board(extra_test, options))
+
+  print(' '.join(target_board_list))
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
The `--with-extra-multilib-test` take the format like below for now.

"<arch>-<abi>-[code-model][;<arch>-<abi>-[code-model]*"

This patch would like to extend the sematic to support additional buil options for each combination. Aka:

"<arch>-<abi>-[code-model][:opts]*[;<arch>-<abi>-[code-model][:opts]*]*"

opts can be one or more build options splited by ':'. For example as below:

* --param=riscv-autovec-lmul=m1
* --param=riscv-autovec-lmul=dynamic:--param=riscv-autovec-preference=fixed-vlmax

Thus the full example of the option `--with-extra-multilib-test` will be:

`rv64gcv_zvl128b-lp64d:--param=riscv-autovec-lmul=m1;rv64gcv_zvl256b-lp64d:- -param=riscv-autovec-lmul=dynamic:--param=riscv-autovec-preference=fixed-vlmax`