### PR TITLE
Improve make report with extra test arguments

### DIFF
--- a/scripts/testsuite-filter
+++ b/scripts/testsuite-filter
@@ -187,6 +187,7 @@ def filter_result(tool, libc, white_list_base_dir, unexpected_results):
             arch = ""
             abi = ""
             cmodel = ""
+            other_args = []
             for info in variation.split('/'):
                 if info.startswith('-march'):
                     arch = info[7:]
@@ -194,13 +195,15 @@ def filter_result(tool, libc, white_list_base_dir, unexpected_results):
                     abi = info[6:]
                 elif info.startswith('-mcmodel'):
                     cmodel = info[9:]
+                elif info != 'riscv-sim':
+                    other_args.append(info)
 
             white_list = \
                 get_white_list(arch, abi, libc,
                                os.path.join(white_list_base_dir, tool),
                                is_gcc)
             # filter!
-            config = (arch, abi, cmodel)
+            config = (arch, abi, cmodel, ":".join(other_args))
             fail_count = 0
             unexpected_result_list = []
             if is_gcc:
@@ -234,8 +237,8 @@ def filter_result(tool, libc, white_list_base_dir, unexpected_results):
 
 
             if len(unexpected_result_list) != 0:
-                print ("\t\t=== %s: Unexpected fails for %s %s %s ===" \
-                       % (testtool, arch, abi, cmodel))
+                print ("\t\t=== %s: Unexpected fails for %s %s %s %s ===" \
+                       % (testtool, arch, abi, cmodel, " ".join(other_args)))
                 for ur in unexpected_result_list:
                     print (ur)
 
@@ -257,7 +260,7 @@ def filter_result(tool, libc, white_list_base_dir, unexpected_results):
         print ("                            | # of unexpected case")
     print ("                            |%s |" % bar)
     for config, result in summary.items():
-        arch, abi, cmodel = config
+        arch, abi, cmodel, other_args = config
         print (" %10s/ %6s/ %6s |" % (arch, abi, cmodel), end='')
         for tool in toollist:
             if tool not in summary[config]:
@@ -271,6 +274,8 @@ def filter_result(tool, libc, white_list_base_dir, unexpected_results):
                 fail_count = summary[config][tool]
                 print ("%13d |" % fail_count, end='')
         print ("")
+        if (len(other_args)):
+            print (" " + other_args.replace(":", " "))
     if any_fail or len(summary.items()) == 0:
         return 1
     else:


### PR DESCRIPTION
Recently we have add the capability to adding extra compilation options for running GCC testsuite, but it seems not handle well on the `make report` part, it will ignore extra compilation options, and then...combine multiple report together.

Now it will put in two different line, and the extra compilation options will listed in follwoing line, here is example output here:

```
               ========= Summary of gcc testsuite =========
                            | # of unexpected case / # of unique unexpected case
                            |          gcc |          g++ |     gfortran |
 rv64gc_zicfilp_zicfiss/  lp64d/ medlow |20350 /  3967 |10158 /  2583 |18374 /  3098 |
 rv64gc_zicfilp_zicfiss/  lp64d/ medlow |   86 /    19 |   15 /     9 |   51 /    51 |
 -static
```