### PR TITLE
Remove ESC char for board extra abi argument

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -97,7 +97,7 @@ GLIBC_TARGET_BOARDS ?= $(shell $(srcdir)/scripts/generate_target_board \
   --sim-name riscv-sim \
   --cmodel $(shell echo @cmodel@ | cut -d '=' -f2) \
   --build-arch-abi $(GLIBC_MULTILIB_NAMES) \
-  --extra-test-arch-abi-flags-list "$(subst ;,\;,$(EXTRA_MULTILIB_TEST))")
+  --extra-test-arch-abi-flags-list "$(EXTRA_MULTILIB_TEST)")
 
 NEWLIB_CC_FOR_TARGET ?= $(NEWLIB_TUPLE)-gcc
 NEWLIB_CXX_FOR_TARGET ?= $(NEWLIB_TUPLE)-g++
@@ -105,13 +105,13 @@ NEWLIB_TARGET_BOARDS ?= $(shell $(srcdir)/scripts/generate_target_board \
   --sim-name riscv-sim \
   --cmodel $(shell echo @cmodel@ | cut -d '=' -f2) \
   --build-arch-abi $(NEWLIB_MULTILIB_NAMES) \
-  --extra-test-arch-abi-flags-list "$(subst ;,\;,$(EXTRA_MULTILIB_TEST))")
+  --extra-test-arch-abi-flags-list "$(EXTRA_MULTILIB_TEST)")
 
 NEWLIB_NANO_TARGET_BOARDS ?= $(shell $(srcdir)/scripts/generate_target_board \
   --sim-name riscv-sim-nano \
   --cmodel $(shell echo @cmodel@ | cut -d '=' -f2) \
   --build-arch-abi $(NEWLIB_MULTILIB_NAMES) \
-  --extra-test-arch-abi-flags-list "$(subst ;,\;,$(EXTRA_MULTILIB_TEST))")
+  --extra-test-arch-abi-flags-list "$(EXTRA_MULTILIB_TEST)")
 NEWLIB_CC_FOR_MULTILIB_INFO := $(NEWLIB_CC_FOR_TARGET)
 
 MUSL_TARGET_FLAGS := $(MUSL_TARGET_FLAGS_EXTRA)


### PR DESCRIPTION
As we have quotes surrounding the argument already, it is unnecessary to ESC `;` to `\;` due to the `;` has special meanings in shell.

Signed-off-by: Pan Li <pan2.li@intel.com>