### PR TITLE
Support Python Virtual Environments while testing

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -907,7 +907,10 @@ stamps/build-pk64: $(PK_SRCDIR) $(PK_SRC_GIT) stamps/build-gcc-newlib-stage2
 	date > $@
 
 stamps/install-python-package:
-	python3 -m pip install --user pyelftools
+	if $(srcdir)/scripts/is_python3_venv 2>/dev/null; \
+		then python3 -m pip install        pyelftools; \
+		else python3 -m pip install --user pyelftools; \
+	fi
 	date > $@
 
 stamps/build-qemu: $(QEMU_SRCDIR) $(QEMU_SRC_GIT)

--- a/scripts/is_python3_venv
+++ b/scripts/is_python3_venv
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+import sys
+
+# cf. <https://docs.python.org/3/library/venv.html#how-venvs-work>
+# cf. <https://peps.python.org/pep-0405/#specification>
+is_venv = (sys.prefix != getattr(sys, "base_prefix", sys.prefix))
+
+print('Python is {}running under a virtual environment.'.format(
+    '' if is_venv else 'not '), file=sys.stderr)
+sys.exit(0 if is_venv else 1)


### PR DESCRIPTION
# Notice

This is intended to provide an "it works by default" solution.

There are multiple ways to manually workaround the issues but I think either documenting required manual commands or removing requirements of such ways is required.  I'll describe some of the ways for workaround.

# The Issue

While testing, it uses a custom Python script which utilizes [pyelftools](https://github.com/eliben/pyelftools) and need to install it when necessary.  But it has a minor issue.

On Ubuntu 23.10, simply `make report` (implicitly with `SIM=qemu`) will fail while installing necessary Python package saying "externally-managed-environment" looking like this:

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.11/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

**Manual Workaround 1**: Set `break-system-packages` in the `global` section of `pip.conf` to `true`, which is considered too dangerous to document.

**Manual Workaround 2**: Let the user install pyelftools manually (on Debian-based distributions, installing `python3-pyelftools`) and also touch the `stamps/install-python-package` file manually.  This is completely safe (and may worth documenting it instead of merging this PR) but makes automation harder.

To avoid this error, [Python Virtual Environments as in PEP 405 (and its module `venv`)](https://peps.python.org/pep-0405/) is normally effective.  However, riscv-gnu-toolchain's `Makefile` has a problem.  riscv-gnu-toolchain tries to use `pip install --user`, which, by default, fails because "user" site-packages are not loaded under a virtual environment.

The error will look like this:

```
ERROR: Can not perform a '--user' install. User site-packages are not visible in this virtualenv.
```

**Manual Workaround 3**: Many recommends changing `include-system-site-packages` in `$VENV/pyvenv.cfg` to `true` manually to avoid this kind of error but it has a simple major pitfall: it taints the user site-packages just like Manual Workaround 1 (and ruins the intent to make a virtual, isolated environment).

# My Proposal

This PR tries to solve this issue by directly supporting Python Virtual Environments from riscv-gnu-toolchain.

The commit stops appending the `--user` option if Python is running under a virtual environment.