### PR TITLE
Bump GNU Binutils to the true v2.41 release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "binutils"]
 	path = binutils
 	url = https://sourceware.org/git/binutils-gdb.git
-	branch = binutils-2_40-branch
+	branch = binutils-2_41-release-point
 [submodule "gcc"]
 	path = gcc
 	url = https://gcc.gnu.org/git/gcc.git

--- a/test/allowlist/binutils/common.log
+++ b/test/allowlist/binutils/common.log
@@ -1,12 +1,1 @@
 #
-# Failures look like:
-# Error: rv64im_zba_zbb_zcb: unknown prefixed ISA extension `zcb'
-# Error: rv32i_zcf: unknown prefixed ISA extension `zcf'
-#
-FAIL: gas/riscv/march-fail-rv64i_zcf
-FAIL: gas/riscv/march-imply-zcd
-FAIL: gas/riscv/march-imply-zcf
-FAIL: gas/riscv/zca
-FAIL: gas/riscv/zcb
-FAIL: gas/riscv/zcd
-FAIL: gas/riscv/zcf


### PR DESCRIPTION
Due to multiple accidents while making a commit corresponding the release of GNU Binutils, version 2.41, there are multiple tags that are broken.

1.  Tag: [`binutils-2_41`](https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=2c73aeb8d2e02de7b69cbcb13361cfbca9d76a4e) on the branch `binutils-2_41-branch`  
    Version files are not properly updated.
2.  Tag: [`binutils-2_41-release`](https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=675b9d612cc59446e84e2c6d89b45500cb603a8d) on the branch `master` (?!)  
     It was an attempt to fix the error but made the situation worse.  This is the corrupted version and makes multiple failures as pointed out by @patrick-rivos.
3.  Head of Branch: [`binutils-2_41-release-point`](https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=49f6117f958cbd22ff93e4ce777a93d9802a402a) (one commit after the tag `binutils-2_41`)  
    This is the correct one to refer.
4.  Tag?: `binutils-2_41-official-release` ([as in the official website](https://www.gnu.org/software/binutils/))
    This tag is somehow not published.

riscv-gnu-toolchain currently points to 2. but this is a broken version with multiple failures.

This PR resolves the problem by pointing 3. of GNU Binutils, corresponding the true release of GNU Binutils version 2.41.

This PR partially reverts commit c7853bf388ff7ce7b67171302956ce78068d2342.