### PR TITLE
Add dependency to Python package installation when `SIM=spike`

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -210,7 +210,7 @@ ifeq ($(SIM),spike)
 # Using spike simulator.
 SIM_PATH:=$(srcdir)/scripts/wrapper/spike:$(srcdir)/scripts
 SIM_PREPARE:=PATH="$(SIM_PATH):$(INSTALL_DIR)/bin:$(PATH)" PK_PATH="$(INSTALL_DIR)/$(NEWLIB_TUPLE)/bin/" ARCH_STR="$(WITH_ARCH)"
-SIM_STAMP:= stamps/build-spike
+SIM_STAMP:= stamps/build-spike stamps/install-python-package
 ifneq (,$(findstring rv32,$(NEWLIB_MULTILIB_NAMES)))
 SIM_STAMP+= stamps/build-pk32
 endif


### PR DESCRIPTION
Since `scripts/wrapper/spike/*` started to use the script `scripts/march-to-cpu-opt`, we need to add dependency to the prerequisite of this script (installation of [pyelftools](https://github.com/eliben/pyelftools)).

This commit adds the dependency to `stamps/install-python-package`.