### PR TITLE
Remove parent's `DEJAGNU` environment variable

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -57,6 +57,9 @@ endif
 
 export PATH AWK SED
 
+# "make report" depends on the default installation of riscv-sim.exp.
+unexport DEJAGNU
+
 MULTILIB_FLAGS := @multilib_flags@
 MULTILIB_GEN := @multilib_gen@
 ifeq ($(MULTILIB_GEN),)


### PR DESCRIPTION
`make report` / `make check` on riscv-gnu-toolchain depends on the default installation of DejaGnu's `riscv-sim.exp`.

If an user overrides the DejaGnu environment with custom `riscv-sim.exp`, many tricks used in the testing framework in riscv-gnu-toolchain stops working.

I noticed this issue while testing riscv-gnu-toolchain with an environment which I use custom DejaGnu configuration to test GCC (alone) with QEMU + custom arguments (written in `$DIR/boards/riscv-sim.exp` where `DEJAGNU=$DIR/site.exp`).

So, this commit removes parent's `DEJAGNU` environment variable by `unexport`ing it.

Note that `unexport` is a feature of GNU Make and (before approving) check whether using a "not in POSIX make" feature is appropriate for this project.