### PR TITLE
Add OR operator for option '--with-extra-multilib-test'

### DIFF
--- a/scripts/generate_target_board
+++ b/scripts/generate_target_board
@@ -29,17 +29,16 @@ def parse_options(argv):
 #   riscv-sim/-march=rv64gcv_zvl256b/-mabi=lp64d/-mcmodel=medlow
 # From the config_string like below, --param is optional
 #   rv64gcv_zvl128b-lp64d:--param=riscv-autovec-lmul=m1
-def generate_one_target_board(config_string, options):
-  configs = config_string.split(":")
-  arch_and_abi = configs[0].split("-")
+def generate_one_target_board(arch_abi, flags, options):
+  arch_and_abi = arch_abi.split("-")
   arch = arch_and_abi[0]
   abi = arch_and_abi[1]
 
-  if len (configs) == 1:
+  if len(flags) == 0:
     return "{0}/-march={1}/-mabi={2}/-mcmodel={3}".format(
       options.sim_name, arch, abi, options.cmodel)
 
-  flags = '/'.join(configs[1:])
+  flags = flags.replace(":", "/")
 
   return "{0}/-march={1}/-mabi={2}/-mcmodel={3}/{4}".format(
     options.sim_name, arch, abi, options.cmodel, flags)
@@ -52,14 +51,25 @@ def main(argv):
     return
 
   target_board_list = [
-    generate_one_target_board(options.build_arch_abi, options)
+    generate_one_target_board(options.build_arch_abi, "", options)
   ]
 
   if options.extra_test_arch_abi_flags_list:
     extra_test_list = options.extra_test_arch_abi_flags_list.split (";")
 
     for extra_test in extra_test_list:
-      target_board_list.append(generate_one_target_board(extra_test, options))
+      idx = extra_test.find(":")
+
+      if idx == -1:
+        one_target_board = generate_one_target_board(extra_test, "", options)
+        target_board_list.append(one_target_board)
+      else:
+        arch_abi = extra_test[:idx - 1]
+        flags = extra_test[idx + 1:]
+
+        for flag in flags.split(","):
+          one_target_board = generate_one_target_board(arch_abi, flag, options)
+          target_board_list.append(one_target_board)
 
   print(' '.join(target_board_list))
 


### PR DESCRIPTION
This patch allows you provide the flags in build flags array acts on arch-abi __respectively__, you can use ',' to separate them. For example:

```
rv64gcv-lp64d:--param=riscv-autovec-lmul=dynamic,--param=riscv-autovec-preference=fixed-vlmax
```

will be consider as two target boards same as below:

```
riscv-sim/-march=rv64gcv/-mabi=lp64d/-mcmodel=medlow/--param=riscv-autovec-preference=fixed-vlmax
riscv-sim/-march=rv64gcv/-mabi=lp64d/-mcmodel=medlow/--param=riscv-autovec-lmul=dynamic
```

However, you can also leverage AND(`:`), OR(`,`) operator together but the OR(`,`) will always have the higher priority. For example:

```
rv64gcv-lp64d:--param=riscv-autovec-lmul=dynamic:--param=riscv-autovec-preference=fixed-vlmax,--param=riscv-autovec-lmul=m2
```

will be consider as tow target boars same as below:

```
riscv-sim/-march=rv64gcv/-mabi=lp64d/-mcmodel=medlow/--param=riscv-autovec-lmul=dynamic/--param=riscv-autovec-preference=fixed-vlmax
riscv-sim/-march=rv64gcv/-mabi=lp64d/-mcmodel=medlow/--param=riscv-autovec-lmul=m2
```