### PR TITLE
Document prerequisites on Testing

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -204,7 +204,7 @@ report-gdb: report-gdb-@default_target@
 ifeq ($(SIM),qemu)
 SIM_PATH:=$(srcdir)/scripts/wrapper/qemu:$(srcdir)/scripts
 SIM_PREPARE:=PATH="$(SIM_PATH):$(INSTALL_DIR)/bin:$(PATH)" RISC_V_SYSROOT="$(SYSROOT)"
-SIM_STAMP:= stamps/build-qemu stamps/install-python-package
+SIM_STAMP:= stamps/build-qemu
 else
 ifeq ($(SIM),spike)
 # Using spike simulator.
@@ -904,10 +904,6 @@ stamps/build-pk64: $(PK_SRCDIR) $(PK_SRC_GIT) stamps/build-gcc-newlib-stage2
 	$(MAKE) -C $(notdir $@)
 	cp $(notdir $@)/pk $(INSTALL_DIR)/$(NEWLIB_TUPLE)/bin/pk64
 	mkdir -p $(dir $@)
-	date > $@
-
-stamps/install-python-package:
-	python3 -m pip install --user pyelftools
 	date > $@
 
 stamps/build-qemu: $(QEMU_SRCDIR) $(QEMU_SRC_GIT)

--- a/README.md
+++ b/README.md
@@ -193,6 +193,34 @@ by the SIM variable in the Makefile, e.g. SIM=qemu, SIM=gdb, or SIM=spike
 (experimental).In addition, the simulator can also be selected with the 
 configure time option `--with-sim=`.However, the testsuite allowlist is 
 only mintained for qemu.Other simulators might get extra failures.
+
+#### Additional Prerequisite
+
+A helper script to setup testing environment requires
+[pyelftools](https://github.com/eliben/pyelftools).
+
+On newer versions of Ubuntu, executing the following command
+should suffice:
+
+    $ sudo apt-get install python3-pyelftools
+
+On newer versions of Fedora and CentOS/RHEL OS (9 or later), executing
+the following command should suffice:
+
+    $ sudo yum install python3-pyelftools
+
+On Arch Linux, executing the following command should suffice:
+
+    $ sudo pacman -Syyu python-pyelftools
+
+If your distribution/OS does not have pyelftools package, you can install
+it using PIP.
+
+    # Assuming that PIP is installed
+    $ pip3 install --user pyelftools
+
+#### Testing GCC
+
 To test GCC, run the following commands:
 
     ./configure --prefix=$RISCV --disable-linux --with-arch=rv64ima # or --with-arch=rv32ima


### PR DESCRIPTION
[pyelftools](https://github.com/eliben/pyelftools) is required for a helper script.

This commit adds basic installation guide to install pyelftools and removes "automatic installation" of pyelftools from Makefile.

This is based on the counter proposal to my #1374+#1376 by @cmuellner (https://github.com/riscv-collab/riscv-gnu-toolchain/pull/1374#issuecomment-1829529123).