### PR TITLE
Add misaligned memory access for spike.

### DIFF
--- a/scripts/wrapper/spike/riscv64-unknown-linux-gnu-run
+++ b/scripts/wrapper/spike/riscv64-unknown-linux-gnu-run
@@ -6,7 +6,8 @@ varch="$(march-to-cpu-opt --elf-file-path $1 --print-spike-varch)"
 
 isa_option="--isa=${isa}"
 varch_option=""
+memory_option="--misaligned"
 
 [[ ! -z ${varch} ]] && varch_option="--varch=${varch}"
 
-spike ${isa_option} ${varch_option} ${PK_PATH}/pk${xlen} "$@"
+spike ${memory_option} ${isa_option} ${varch_option} ${PK_PATH}/pk${xlen} "$@"


### PR DESCRIPTION
The spec does not forbid the misaligned memory access. And the gcc will generate vector load/store to access misaligned memory by default.

Currently the QEMU supports this feature, so to support in spike is also make sense.

Reference test case: gcc/gcc/testsuite/gcc.dg/vect/vect-align-1.c