### PR TITLE
Fix one bug of generate target board

### DIFF
--- a/scripts/generate_target_board
+++ b/scripts/generate_target_board
@@ -64,7 +64,7 @@ def main(argv):
         one_target_board = generate_one_target_board(extra_test, "", options)
         target_board_list.append(one_target_board)
       else:
-        arch_abi = extra_test[:idx - 1]
+        arch_abi = extra_test[:idx]
         flags = extra_test[idx + 1:]
 
         for flag in flags.split(","):


### PR DESCRIPTION
The default value of subarray is the length, thus we should take `idx` instead of `idx - 1` here.