### PR TITLE
Fix one bug of spike varch elen

### DIFF
--- a/scripts/generate_target_board
+++ b/scripts/generate_target_board
@@ -64,7 +64,7 @@ def main(argv):
         one_target_board = generate_one_target_board(extra_test, "", options)
         target_board_list.append(one_target_board)
       else:
-        arch_abi = extra_test[:idx - 1]
+        arch_abi = extra_test[:idx]
         flags = extra_test[idx + 1:]
 
         for flag in flags.split(","):

--- a/scripts/march-to-cpu-opt
+++ b/scripts/march-to-cpu-opt
@@ -41,6 +41,7 @@ SPIKE_EXT_NOT_ALLOWED = [
 CPU_OPTIONS = {
   "xlen":            "",
   "vlen":            "",
+  "elen":            "",
   "extensions":      [],
 }
 
@@ -146,6 +147,14 @@ def get_vlen(ext_dict):
             vlen = max(vlen, zvelen)
     return vlen
 
+def get_elen(ext_dict):
+    elen = 32
+
+    if "zve64x" in ext_dict or "zve64f" in ext_dict or "zve64d" in ext_dict:
+        elen = 64
+
+    return elen
+
 def print_qemu_cpu():
     cpu_options = []
     cpu_options.append("rv{0}".format(CPU_OPTIONS['xlen']))
@@ -186,7 +195,7 @@ def print_spike_varch():
     if not CPU_OPTIONS['vlen']:
         return ""
 
-    return "vlen:{0},elen:{1}".format(CPU_OPTIONS['vlen'], CPU_OPTIONS['xlen'])
+    return "vlen:{0},elen:{1}".format(CPU_OPTIONS['vlen'], CPU_OPTIONS['elen'])
 
 class TestArchStringParse(unittest.TestCase):
     def _test(self, arch, expected_arch_list, expected_vlen=0):
@@ -256,6 +265,7 @@ def parse_elf_file(elf_file_path):
 
     CPU_OPTIONS["extensions"] = extensions
     CPU_OPTIONS["vlen"] = get_vlen(extension_dict)
+    CPU_OPTIONS["elen"] = get_elen(extension_dict)
     CPU_OPTIONS["xlen"] = get_xlen(elf_file_path)
 
 def main(argv):

--- a/scripts/march-to-cpu-opt
+++ b/scripts/march-to-cpu-opt
@@ -147,9 +147,11 @@ def get_vlen(ext_dict):
             vlen = max(vlen, zvelen)
     return vlen
 
-def get_elen(ext_dict):
-    elen = 32
+def get_elen(ext_dict, xlen):
+    elen = xlen
 
+    if "zve32x" in ext_dict or "zve32f" in ext_dict:
+        elen = 32
     if "zve64x" in ext_dict or "zve64f" in ext_dict or "zve64d" in ext_dict:
         elen = 64
 
@@ -263,10 +265,12 @@ def parse_elf_file(elf_file_path):
     for extension in extension_dict.keys():
         extensions.append(extension)
 
+    xlen = get_xlen(elf_file_path)
+
     CPU_OPTIONS["extensions"] = extensions
     CPU_OPTIONS["vlen"] = get_vlen(extension_dict)
-    CPU_OPTIONS["elen"] = get_elen(extension_dict)
-    CPU_OPTIONS["xlen"] = get_xlen(elf_file_path)
+    CPU_OPTIONS["elen"] = get_elen(extension_dict, xlen)
+    CPU_OPTIONS["xlen"] = xlen
 
 def main(argv):
     opt = parse_opt(argv)


### PR DESCRIPTION
According to the ISA, the zve32/zve64 xdf decides the elen of the RVV. Thus we should pick up the extensions instead of the xlen for the spike varch generation.