### PR TITLE
fix multilib support and rework --with-extra-multilib-test

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -59,14 +59,20 @@ export PATH AWK SED
 
 MULTILIB_FLAGS := @multilib_flags@
 MULTILIB_GEN := @multilib_gen@
+TEST_FLAGS := @test_flags@
 ifeq ($(MULTILIB_GEN),)
+GLIBC_MULTILIB_NAMES := @glibc_multilib_names@
 NEWLIB_MULTILIB_NAMES := @newlib_multilib_names@
 GCC_MULTILIB_FLAGS := $(MULTILIB_FLAGS)
+NEWLIB_TARGET_BOARD_CONFIG := $(NEWLIB_MULTILIB_NAMES):$(TEST_FLAGS)
+GLIBC_TARGET_BOARD_CONFIG := $(GLIBC_MULTILIB_NAMES):$(TEST_FLAGS)
 else
 NEWLIB_MULTILIB_NAMES := $(shell echo "$(MULTILIB_GEN)" | $(SED) 's/;/\n/g' | $(SED) '/^$$/d' | $(AWK) '{split($$0,a,"-"); printf "%s-%s ", a[1],a[2]}')
-GCC_MULTILIB_FLAGS := $(MULTILIB_FLAGS) --with-multilib-generator="$(MULTILIB_GEN)"
+NEWLIB_TARGET_BOARD_CONFIG := $(shell echo "$(MULTILIB_GEN)" | $(SED) 's/;/\n/g' | $(SED) '/^$$/d' | $(AWK) '{n=split($$0,a,"-"); m=split($$0,b,":"); joined=""; for(i=2;i<=m;i++) { joined=joined":"b[i]; }  printf "%s-%s:%s ", a[1],a[2],joined}')
+GLIBC_MULTILIB_NAMES := $(shell echo "$(MULTILIB_GEN)" | $(SED) 's/;/\n/g' | $(SED) '/^$$/d' | $(AWK) '{split($$0,a,"-"); printf "%s-%s ", a[1],a[2]}')
+GLIBC_TARGET_BOARD_CONFIG := $(shell echo "$(MULTILIB_GEN)" | $(SED) 's/;/\n/g' | $(SED) '/^$$/d' | $(AWK) '{n=split($$0,a,"-"); m=split($$0,b,":"); joined=""; for(i=2;i<=m;i++) { joined=joined":"b[i]; }  printf "%s-%s:%s ", a[1],a[2],joined}')
+GCC_MULTILIB_FLAGS := $(MULTILIB_FLAGS) --with-multilib-generator="$(shell echo "$(MULTILIB_GEN)" | $(SED) 's/;/\n/g' | $(SED) '/^$$/d' | $(AWK) '{split($$0,a,"-"); printf "%s-%s--;", a[1],a[2]}')"
 endif
-GLIBC_MULTILIB_NAMES := @glibc_multilib_names@
 GCC_CHECKING_FLAGS := @gcc_checking@
 
 EXTRA_MULTILIB_TEST := @extra_multilib_test@
@@ -96,22 +102,19 @@ GLIBC_CXX_FOR_TARGET ?= $(LINUX_TUPLE)-g++
 GLIBC_TARGET_BOARDS ?= $(shell $(srcdir)/scripts/generate_target_board \
   --sim-name riscv-sim \
   --cmodel $(shell echo @cmodel@ | cut -d '=' -f2) \
-  --build-arch-abi $(GLIBC_MULTILIB_NAMES) \
-  --extra-test-arch-abi-flags-list "$(EXTRA_MULTILIB_TEST)")
+  --target-arch-abi-flags-list "$(GLIBC_TARGET_BOARD_CONFIG)")
 
 NEWLIB_CC_FOR_TARGET ?= $(NEWLIB_TUPLE)-gcc
 NEWLIB_CXX_FOR_TARGET ?= $(NEWLIB_TUPLE)-g++
 NEWLIB_TARGET_BOARDS ?= $(shell $(srcdir)/scripts/generate_target_board \
   --sim-name riscv-sim \
   --cmodel $(shell echo @cmodel@ | cut -d '=' -f2) \
-  --build-arch-abi $(NEWLIB_MULTILIB_NAMES) \
-  --extra-test-arch-abi-flags-list "$(EXTRA_MULTILIB_TEST)")
+  --target-arch-abi-flags-list "$(NEWLIB_TARGET_BOARD_CONFIG)")
 
 NEWLIB_NANO_TARGET_BOARDS ?= $(shell $(srcdir)/scripts/generate_target_board \
   --sim-name riscv-sim-nano \
   --cmodel $(shell echo @cmodel@ | cut -d '=' -f2) \
-  --build-arch-abi $(NEWLIB_MULTILIB_NAMES) \
-  --extra-test-arch-abi-flags-list "$(EXTRA_MULTILIB_TEST)")
+  --target-arch-abi-flags-list "$(NEWLIB_TARGET_BOARD_CONFIG)")
 NEWLIB_CC_FOR_MULTILIB_INFO := $(NEWLIB_CC_FOR_TARGET)
 
 MUSL_TARGET_FLAGS := $(MUSL_TARGET_FLAGS_EXTRA)

--- a/configure
+++ b/configure
@@ -610,6 +610,7 @@ gcc_checking
 musl_multilib_names
 newlib_multilib_names
 glibc_multilib_names
+test_flags
 multilib_flags
 extra_multilib_test
 multilib_gen
@@ -685,6 +686,7 @@ with_abi
 with_tune
 with_isa_spec
 with_sim
+with_test_flags
 enable_multilib
 with_multilib_generator
 with_extra_multilib_test
@@ -1353,6 +1355,7 @@ Optional Packages:
                           Set the default ISA spec version, default to
                           20191213, available options: 2.2, 20190608, 20191213
   --with-sim=qemu         Sets the base RISC-V Simulator, defaults to qemu
+  --with-test-flags       Adds additional testing flag configurations
   --with-multilib-generator
                           Multi-libs configuration string, only supported for
                           bare-metal/elf toolchain, this option implied
@@ -3409,6 +3412,19 @@ WITH_ISA_SPEC=--with-isa-spec=$with_isa_spec
 
 WITH_SIM=$with_sim
 
+
+# Check whether --with-test-flags was given.
+if test "${with_test_flags+set}" = set; then :
+  withval=$with_test_flags;
+else
+  with_test_flags=no
+fi
+
+if test "x$with_test_flags" != xno; then :
+  test_flags="$with_test_flags"
+else
+  test_flags=""
+fi
 
 # Check whether --enable-multilib was given.
 if test "${enable_multilib+set}" = set; then :

--- a/configure.ac
+++ b/configure.ac
@@ -120,6 +120,13 @@ AC_SUBST(WITH_TUNE, --with-tune=$with_tune)
 AC_SUBST(WITH_ISA_SPEC, --with-isa-spec=$with_isa_spec)
 AC_SUBST(WITH_SIM, $with_sim)
 
+AC_ARG_WITH(test-flags,
+	[AS_HELP_STRING([--with-test-flags],
+		[Adds additional testing flag configurations])],
+	[],
+	[with_test_flags=no]
+	)
+
 AC_ARG_ENABLE(multilib,
 	[AS_HELP_STRING([--enable-multilib],
 		[build both RV32 and RV64 runtime libraries (only RV64 for musl libc) @<:@--disable-multilib@:>@])],
@@ -144,6 +151,10 @@ AC_ARG_WITH(extra-multilib-test,
 AS_IF([test "x$with_multilib_generator" != xno],
         [AC_SUBST(multilib_gen,"$with_multilib_generator")],
         [AC_SUBST(multilib_gen,"")])
+
+AS_IF([test "x$with_test_flags" != xno],
+        [AC_SUBST(test_flags,"$with_test_flags")],
+        [AC_SUBST(test_flags,"")])
 
 AS_IF([test "x$with_extra_multilib_test" != xno],
         [AC_SUBST(extra_multilib_test,"$with_extra_multilib_test")],

--- a/scripts/generate_target_board
+++ b/scripts/generate_target_board
@@ -8,13 +8,8 @@ def parse_options(argv):
 
   parser.add_argument('--sim-name', type = str, required = True,
                       help = 'The sim name of target board, like riscv-sim.')
-  parser.add_argument('--build-arch-abi', type = str, required = True,
-                      help = 'The arch and abi when build, like ' +
-                             '--with-arch=rv64gcv --with-abi=lp64d' +
-                             'in riscv-gnu-toolchain configure, ' +
-                             'within format rv64gcv-lp64d.')
-  parser.add_argument('--extra-test-arch-abi-flags-list', type=str,
-                      help = 'The arch, abi and flags list for extra test,' +
+  parser.add_argument('--target-arch-abi-flags-list', type=str,
+                      help = 'The arch, abi and flags list for testing,' +
                              'like =rv64gcv_zvl256b-lp64d:' +
                              '--param=riscv-autovec-lmul=dynamic:' +
                              '--param=riscv-autovec-preference=fixed-vlmax.',
@@ -42,34 +37,32 @@ def generate_one_target_board(arch_abi, flags, options):
 
   return "{0}/-march={1}/-mabi={2}/-mcmodel={3}/{4}".format(
     options.sim_name, arch, abi, options.cmodel, flags)
-
+ 
 def main(argv):
   options = parse_options(argv)
 
-  if not options.sim_name or not options.build_arch_abi:
+  if not options.sim_name or not options.target_arch_abi_flags_list:
     print ("The --sim-name and/or --build-arch-abi cannot be empty or null.")
     return
 
-  target_board_list = [
-    generate_one_target_board(options.build_arch_abi, "", options)
-  ]
+  test_list = options.target_arch_abi_flags_list.strip().replace("::", ":").split(" ")
+  
+  target_board_list = []
 
-  if options.extra_test_arch_abi_flags_list:
-    extra_test_list = options.extra_test_arch_abi_flags_list.split (";")
 
-    for extra_test in extra_test_list:
-      idx = extra_test.find(":")
+  for extra_test in test_list:
+    idx = extra_test.find(":")
 
-      if idx == -1:
-        one_target_board = generate_one_target_board(extra_test, "", options)
+    if idx == -1:
+      one_target_board = generate_one_target_board(extra_test, "", options)
+      target_board_list.append(one_target_board)
+    else:
+      arch_abi = extra_test[:idx]
+      flags = extra_test[idx + 1:]
+
+      for flag in flags.split(","):
+        one_target_board = generate_one_target_board(arch_abi, flag, options)
         target_board_list.append(one_target_board)
-      else:
-        arch_abi = extra_test[:idx]
-        flags = extra_test[idx + 1:]
-
-        for flag in flags.split(","):
-          one_target_board = generate_one_target_board(arch_abi, flag, options)
-          target_board_list.append(one_target_board)
 
   print(' '.join(target_board_list))
 


### PR DESCRIPTION
This pull request allows the following functionality:
1. Enable multilib support with `generate_target_board.py` and allow additional testing configurations without needing `--with-extra-multilib-test` flag
2. Enable linux multilib support using `--with-multilib-generator`
---
Currently `--with-multilib-generator` with more than one target is not supported with `generate_target_board.py`. For example, 
```
  $ ../configure --prefix=/scratch/ewlu/ci/triage/other/build-newlib --with-multilib-generator="rv64gcv-lp64d--;rv32gcv-ilp32d--"
```
will have an error 
```
usage: generate_target_board [-h] --sim-name SIM_NAME --build-arch-abi
                             BUILD_ARCH_ABI
                             [--extra-test-arch-abi-flags-list EXTRA_TEST_ARCH_ABI_FLAGS_LIST]
                             [--cmodel CMODEL]
generate_target_board: error: unrecognized arguments: rv32gcv-ilp32d
```
This is because `generate_target_board` expects `rv32gcv-ilp32d` to be passed in through `--with-extra-multilib-test`.

 We fix `generate_target_board.py`'s problem with multilib by changing the script arguments to accept a list of different configurations while maintaining the internal logic

For example, instead of running configure flags
`--with-arch=rv64gc --with-abi=lp64d --with-extra-multilib-test="rv64gcv-lp64d:--param=riscv-autovec-lmul=dynamic:--param=riscv-autovec-preference=fixed-vlmax;rv64gcv_zba-lp64d"`
to generate
```
riscv-sim/-march=rv64gc/-mabi=lp64d/-mcmodel=medlow
riscv-sim/-march=rv64gcv/-mabi=lp64d/-mcmodel=medlow/--param=riscv-autovec-lmul=dynamic/--param=riscv-autovec-preference=fixed-vlmax
riscv-sim/-march=rv64gcv_zba/-mabi=lp64d/-mcmodel=medlow
```
we can run
`--with-multilib-generator="rv64gc-lp64d--;rv64gcv-lp64d--:--param=riscv-autovec-lmul=dynamic:--param=riscv-autovec-preference=fixed-vlmax;rv64gcv_zba-lp64d--`
to generate the same boards
Alternatively, if we just want to run one target, the new flag `--with-test-flags` enables single target flexibility so
`--with-arch=rv64gcv --with-abi=lp64d --with-test-flags="--param=riscv-autovec-lmul=dynamic:--param=riscv-autovec-preference=fixed-vlmax"`
will generate target board 
```
riscv-sim/-march=rv64gcv/-mabi=lp64d/-mcmodel=medlow/--param=riscv-autovec-lmul=dynamic/--param=riscv-autovec-preference=fixed-vlmax
```
---
`--with-multilib-generator="<targets>"` will fail with `make report-linux` because the desired targets will always be overwritten with the defaults (therefore testing incorrect targets). This supports the intended linux multilib builds and tests.
