### PR TITLE
Bump binutils to v2.42 release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "binutils"]
 	path = binutils
 	url = https://sourceware.org/git/binutils-gdb.git
-	branch = binutils-2_41-release-point
+	branch = binutils-2_42-branch
 [submodule "gcc"]
 	path = gcc
 	url = https://gcc.gnu.org/git/gcc.git


### PR DESCRIPTION
Test results:
```
               ========= Summary of gcc testsuite =========
                            | # of unexpected case / # of unique unexpected case
                            |          gcc |          g++ |     gfortran |
     rv64gc/  lp64d/ medlow |    0 /     0 |    0 /     0 |    0 /     0 |
     rv32gc/ ilp32d/ medlow |    0 /     0 |    0 /     0 |    0 /     0 |
```