### PR TITLE
Add support to build a host GCC for building the toolchain

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -119,8 +119,14 @@ MUSL_CC_FOR_TARGET ?= $(MUSL_TUPLE)-gcc
 MUSL_CXX_FOR_TARGET ?= $(MUSL_TUPLE)-g++
 
 CONFIGURE_HOST   = @configure_host@
+PREPARATION_STAMP:=stamps/check-write-permission
 
 all: @default_target@
+ifeq (@enable_host_gcc@,--enable-host-gcc)
+PREPARATION_STAMP+= stamps/install-host-gcc
+PATH := $(builddir)/install-host-gcc/bin:$(PATH)
+GCC_CHECKING_FLAGS := $(GCC_CHECKING_FLAGS) --enable-werror-always
+endif
 newlib: stamps/build-gcc-newlib-stage2
 linux: stamps/build-gcc-linux-stage2
 ifneq (,$(findstring riscv32,$(MUSL_TUPLE)))
@@ -324,11 +330,25 @@ $(srcdir)/%/.git:
 	flock `git rev-parse --git-dir`/config git submodule init $(dir $@) && \
 	flock `git rev-parse --git-dir`/config git submodule update $(dir $@)
 
+stamps/install-host-gcc: $(GCC_SRCDIR) $(GCC_SRC_GIT)
+	if test -f $</contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" = "true"; then cd $< && ./contrib/download_prerequisites; fi
+	rm -rf $@ $(notdir $@)
+	mkdir $(notdir $@)
+	cd $(notdir $@) && $</configure \
+		--prefix=$(builddir)/install-host-gcc \
+		@with_system_zlib@ \
+		--enable-languages=c,c++ \
+		--disable-bootstrap \
+		--disable-multilib
+	$(MAKE) -C $(notdir $@)
+	$(MAKE) -C $(notdir $@) install
+	mkdir -p $(dir $@) && touch $@
+
 #
 # GLIBC
 #
 
-stamps/build-binutils-linux: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/check-write-permission
+stamps/build-binutils-linux: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) $(PREPARATION_STAMP)
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 # CC_FOR_TARGET is required for the ld testsuite.
@@ -351,7 +371,7 @@ stamps/build-binutils-linux: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/check
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gdb-linux: $(GDB_SRCDIR) $(GDB_SRC_GIT)
+stamps/build-gdb-linux: $(GDB_SRCDIR) $(GDB_SRC_GIT) $(PREPARATION_STAMP)
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 # CC_FOR_TARGET is required for the ld testsuite.
@@ -498,7 +518,7 @@ stamps/build-gcc-linux-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) $(addprefix stamps/b
 	cp -a $(INSTALL_DIR)/$(LINUX_TUPLE)/lib* $(SYSROOT)
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-binutils-linux-native: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/build-gcc-linux-stage2 stamps/check-write-permission
+stamps/build-binutils-linux-native: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/build-gcc-linux-stage2 $(PREPARATION_STAMP)
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \
@@ -555,7 +575,7 @@ stamps/build-gcc-linux-native: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-gcc-lin
 # NEWLIB
 #
 
-stamps/build-binutils-newlib: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/check-write-permission
+stamps/build-binutils-newlib: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) $(PREPARATION_STAMP)
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 # CC_FOR_TARGET is required for the ld testsuite.
@@ -575,7 +595,7 @@ stamps/build-binutils-newlib: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/chec
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gdb-newlib: $(GDB_SRCDIR) $(GDB_SRC_GIT)
+stamps/build-gdb-newlib: $(GDB_SRCDIR) $(GDB_SRC_GIT) $(PREPARATION_STAMP)
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 # CC_FOR_TARGET is required for the ld testsuite.
@@ -741,7 +761,7 @@ stamps/build-gcc-newlib-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-newlib
 # MUSL
 #
 
-stamps/build-binutils-musl: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/check-write-permission
+stamps/build-binutils-musl: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) $(PREPARATION_STAMP)
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 # CC_FOR_TARGET is required for the ld testsuite.
@@ -870,7 +890,7 @@ stamps/build-gcc-musl-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-musl-lin
 	cp -a $(INSTALL_DIR)/$(MUSL_TUPLE)/lib* $(SYSROOT)
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-spike: $(SPIKE_SRCDIR) $(SPIKE_SRC_GIT)
+stamps/build-spike: $(SPIKE_SRCDIR) $(SPIKE_SRC_GIT) $(PREPARATION_STAMP)
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \
@@ -906,7 +926,7 @@ stamps/build-pk64: $(PK_SRCDIR) $(PK_SRC_GIT) stamps/build-gcc-newlib-stage2
 	mkdir -p $(dir $@)
 	date > $@
 
-stamps/build-qemu: $(QEMU_SRCDIR) $(QEMU_SRC_GIT)
+stamps/build-qemu: $(QEMU_SRCDIR) $(QEMU_SRC_GIT) $(PREPARATION_STAMP)
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \
@@ -971,7 +991,7 @@ stamps/build-llvm-newlib: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) stamps/build-gcc-newlib
 	    ln -s -f clang++ $(NEWLIB_TUPLE)-clang++
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-dejagnu: $(DEJAGNU_SRCDIR) $(DEJAGNU_SRC_GIT)
+stamps/build-dejagnu: $(DEJAGNU_SRCDIR) $(DEJAGNU_SRC_GIT) $(PREPARATION_STAMP)
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \
@@ -1101,7 +1121,7 @@ report-binutils-linux: stamps/check-binutils-linux
 	    `find build-binutils-linux/ -name *.sum |paste -sd "," -`
 
 clean:
-	rm -rf build-* stamps install-newlib-nano
+	rm -rf build-* install-* stamps install-newlib-nano
 
 .PHONY: report-gdb-newlib report-gdb-newlib-nano
 report-gdb-newlib: stamps/check-gdb-newlib

--- a/README.md
+++ b/README.md
@@ -447,3 +447,13 @@ Here is the list of configure option for specify source tree:
     --with-pk-src
     --with-qemu-src
     --with-spike-src
+
+#### Build host GCC to check for compiler warnings
+
+GCC contributions have to meet several requirements to qualify for upstream
+inclusion.  Warning free compilation with a compiler build from the same
+sources is among them.  The flag `--enable-host-gcc` does exaclty that:
+
+* Initially a host GCC will be built
+* This host GCC is then used to build the cross compiler
+* The cross compiler will be built with `-Werror` to identify code issues

--- a/configure
+++ b/configure
@@ -598,6 +598,7 @@ with_glibc_src
 with_newlib_src
 with_binutils_src
 with_gcc_src
+enable_host_gcc
 enable_llvm
 enable_gdb
 with_guile
@@ -697,6 +698,7 @@ with_system_zlib
 with_guile
 enable_gdb
 enable_llvm
+enable_host_gcc
 with_gcc_src
 with_binutils_src
 with_newlib_src
@@ -1340,6 +1342,7 @@ Optional Features:
                           [--disable-gcc-checking]
   --disable-gdb           Don't build GDB, as it's not upstream
   --enable-llvm           Build LLVM (clang)
+  --enable-host-gcc       Build host GCC to build cross toolchain
   --enable-libsanitizer   Build libsanitizer, which only supports rv64
   --enable-qemu-system    Build qemu with system-mode emulation
 
@@ -3620,6 +3623,20 @@ if test "x$enable_llvm" != xyes; then :
 
 else
   enable_llvm=--enable-llvm
+
+fi
+
+# Check whether --enable-host-gcc was given.
+if test "${enable_host_gcc+set}" = set; then :
+  enableval=$enable_host_gcc; enable_host_gcc=yes
+fi
+
+
+if test "x$enable_host_gcc" != xyes; then :
+  enable_host_gcc=--disable-host-gcc
+
+else
+  enable_host_gcc=--enable-host-gcc
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -259,6 +259,16 @@ AS_IF([test "x$enable_llvm" != xyes],
 	[AC_SUBST(enable_llvm, --disable-llvm)],
 	[AC_SUBST(enable_llvm, --enable-llvm)])
 
+AC_ARG_ENABLE(host_gcc,
+	[AS_HELP_STRING([--enable-host-gcc],
+		[Build host GCC to build cross toolchain])],
+	[enable_host_gcc=yes],
+	[])
+
+AS_IF([test "x$enable_host_gcc" != xyes],
+	[AC_SUBST(enable_host_gcc, --disable-host-gcc)],
+	[AC_SUBST(enable_host_gcc, --enable-host-gcc)])
+
 AC_DEFUN([AX_ARG_WITH_SRC],
 	[{m4_pushdef([opt_name], with_$1_src)
 	  AC_ARG_WITH($1-src,


### PR DESCRIPTION
A significant amount of users of this project are using it for toolchain development. These users need to ensure that their code is warning free before submitting it upstream. Let's support this use case by adding a configure flag '--enable-host-gcc', which does exactly that:
* build a host GCC before building other components
* setting PATH such that this new GCC is used to build the cross toolchain
* enable -Werror for the GCC build

This patch was tested on a Fedora 39 machine (GCC 13), with the following modification in a GCC source file:
```
  #if __GNUC__ == 13
  #error Host compiler in use!
  #endif
```
This fails when building without the new flag and does not fail when building with latest upstream/master (GCC 14 prerelease).

The '--enable-werror-always' was tested with a warning that showed up recently in upstream GCC.