### PR TITLE
Add LTO support of Clang/LLVM

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -337,7 +337,6 @@ stamps/build-binutils-linux: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/check
 		$(CONFIGURE_HOST) \
 		--prefix=$(INSTALL_DIR) \
 		--with-sysroot=$(SYSROOT) \
-		--enable-gold \
 		--enable-plugins \
 		$(MULTILIB_FLAGS) \
 		@with_guile@ \
@@ -508,7 +507,6 @@ stamps/build-binutils-linux-native: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamp
 		--target=$(LINUX_TUPLE) \
 		$(CONFIGURE_HOST) \
 		--prefix=$(INSTALL_DIR)/native \
-		--enable-gold \
 		--enable-plugins \
 		$(MULTILIB_FLAGS) \
 		@with_guile@ \
@@ -567,7 +565,6 @@ stamps/build-binutils-newlib: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/chec
 		--target=$(NEWLIB_TUPLE) \
 		$(CONFIGURE_HOST) \
 		--prefix=$(INSTALL_DIR) \
-		--enable-gold \
 		--enable-plugins \
 		@with_guile@ \
 		--disable-werror \
@@ -756,7 +753,6 @@ stamps/build-binutils-musl: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/check-
 		$(CONFIGURE_HOST) \
 		--prefix=$(INSTALL_DIR) \
 		--with-sysroot=$(SYSROOT) \
-		--enable-gold \
 		--enable-plugins \
 		$(MULTILIB_FLAGS) \
 		@with_guile@ \
@@ -927,7 +923,7 @@ stamps/build-qemu: $(QEMU_SRCDIR) $(QEMU_SRC_GIT)
 	mkdir -p $(dir $@)
 	date > $@
 
-stamps/build-llvm-linux: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) \
+stamps/build-llvm-linux: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) \
                          stamps/build-gcc-linux-stage2
 	# We have the following situation:
 	# - sysroot directory: $(INSTALL_DIR)/sysroot
@@ -954,7 +950,7 @@ stamps/build-llvm-linux: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) \
 	    -DDEFAULT_SYSROOT="../sysroot" \
 	    -DLLVM_RUNTIME_TARGETS=$(call make_tuple,$(XLEN),linux-gnu) \
 	    -DLLVM_INSTALL_TOOLCHAIN_ONLY=On \
-	    -DLLVM_BINUTILS_INCDIR=`find $(INSTALL_DIR) -name plugin-api.h | xargs dirname` \
+	    -DLLVM_BINUTILS_INCDIR=$(BINUTILS_SRCDIR)/include \
 	    -DLLVM_PARALLEL_LINK_JOBS=4
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
@@ -963,7 +959,8 @@ stamps/build-llvm-linux: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) \
 	cd $(INSTALL_DIR)/bin && ln -s -f clang $(LINUX_TUPLE)-clang && ln -s -f clang++ $(LINUX_TUPLE)-clang++
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-llvm-newlib: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) stamps/build-gcc-newlib-stage2
+stamps/build-llvm-newlib: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) \
+                          stamps/build-gcc-newlib-stage2
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && \
@@ -974,7 +971,7 @@ stamps/build-llvm-newlib: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) stamps/build-gcc-newlib
 	    -DLLVM_ENABLE_PROJECTS="clang;lld" \
 	    -DLLVM_DEFAULT_TARGET_TRIPLE="$(NEWLIB_TUPLE)" \
 	    -DLLVM_INSTALL_TOOLCHAIN_ONLY=On \
-	    -DLLVM_BINUTILS_INCDIR=`find $(INSTALL_DIR) -name plugin-api.h | xargs dirname` \
+	    -DLLVM_BINUTILS_INCDIR=$(BINUTILS_SRCDIR)/include \
 	    -DLLVM_PARALLEL_LINK_JOBS=4
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install

--- a/Makefile.in
+++ b/Makefile.in
@@ -337,6 +337,8 @@ stamps/build-binutils-linux: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/check
 		$(CONFIGURE_HOST) \
 		--prefix=$(INSTALL_DIR) \
 		--with-sysroot=$(SYSROOT) \
+		--enable-gold \
+		--enable-plugins \
 		$(MULTILIB_FLAGS) \
 		@with_guile@ \
 		--disable-werror \
@@ -506,6 +508,8 @@ stamps/build-binutils-linux-native: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamp
 		--target=$(LINUX_TUPLE) \
 		$(CONFIGURE_HOST) \
 		--prefix=$(INSTALL_DIR)/native \
+		--enable-gold \
+		--enable-plugins \
 		$(MULTILIB_FLAGS) \
 		@with_guile@ \
 		--disable-werror \
@@ -563,6 +567,8 @@ stamps/build-binutils-newlib: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/chec
 		--target=$(NEWLIB_TUPLE) \
 		$(CONFIGURE_HOST) \
 		--prefix=$(INSTALL_DIR) \
+		--enable-gold \
+		--enable-plugins \
 		@with_guile@ \
 		--disable-werror \
 		$(BINUTILS_TARGET_FLAGS) \
@@ -750,6 +756,8 @@ stamps/build-binutils-musl: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/check-
 		$(CONFIGURE_HOST) \
 		--prefix=$(INSTALL_DIR) \
 		--with-sysroot=$(SYSROOT) \
+		--enable-gold \
+		--enable-plugins \
 		$(MULTILIB_FLAGS) \
 		@with_guile@ \
 		--disable-werror \
@@ -946,10 +954,12 @@ stamps/build-llvm-linux: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) \
 	    -DDEFAULT_SYSROOT="../sysroot" \
 	    -DLLVM_RUNTIME_TARGETS=$(call make_tuple,$(XLEN),linux-gnu) \
 	    -DLLVM_INSTALL_TOOLCHAIN_ONLY=On \
+	    -DLLVM_BINUTILS_INCDIR=`find $(INSTALL_DIR) -name plugin-api.h | xargs dirname` \
 	    -DLLVM_PARALLEL_LINK_JOBS=4
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	cp $(notdir $@)/lib/riscv$(XLEN)-unknown-linux-gnu/libc++* $(SYSROOT)/lib
+	cp $(notdir $@)/lib/LLVMgold.so  $(INSTALL_DIR)/lib
 	cd $(INSTALL_DIR)/bin && ln -s -f clang $(LINUX_TUPLE)-clang && ln -s -f clang++ $(LINUX_TUPLE)-clang++
 	mkdir -p $(dir $@) && touch $@
 
@@ -964,9 +974,11 @@ stamps/build-llvm-newlib: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) stamps/build-gcc-newlib
 	    -DLLVM_ENABLE_PROJECTS="clang;lld" \
 	    -DLLVM_DEFAULT_TARGET_TRIPLE="$(NEWLIB_TUPLE)" \
 	    -DLLVM_INSTALL_TOOLCHAIN_ONLY=On \
+	    -DLLVM_BINUTILS_INCDIR=`find $(INSTALL_DIR) -name plugin-api.h | xargs dirname` \
 	    -DLLVM_PARALLEL_LINK_JOBS=4
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
+	cp $(notdir $@)/lib/LLVMgold.so  $(INSTALL_DIR)/lib
 	cd $(INSTALL_DIR)/bin && ln -s -f clang $(NEWLIB_TUPLE)-clang && \
 	    ln -s -f clang++ $(NEWLIB_TUPLE)-clang++
 	mkdir -p $(dir $@) && touch $@


### PR DESCRIPTION
We need to build LLVMgold.so and copy it to installation dir.

I think it deserves to be default, so I don't add an option to enable
this.

Fixes #1429