### PR TITLE
RISCV: Add target_board generation for multiple arch_abi parameters 

### DIFF
--- a/scripts/generate_target_board
+++ b/scripts/generate_target_board
@@ -50,9 +50,14 @@ def main(argv):
     print ("The --sim-name and/or --build-arch-abi cannot be empty or null.")
     return
 
-  target_board_list = [
-    generate_one_target_board(options.build_arch_abi, "", options)
-  ]
+  target_board_list = []
+  arch_abi_list = [options.build_arch_abi]
+  if ' ' in options.build_arch_abi:
+    arch_abi_list = options.build_arch_abi.split (" ")
+
+  for one_arch_abi in arch_abi_list:
+    target_board = generate_one_target_board(one_arch_abi, "", options)
+    target_board_list.append(target_board)
 
   if options.extra_test_arch_abi_flags_list:
     extra_test_list = options.extra_test_arch_abi_flags_list.split (";")


### PR DESCRIPTION
Currently this script just can handle one parameter for arch_abi,but there is more than one arch_abi in "newlib_multilib_names" which comes from the configure.

Execute the following command:
generate_target_board --sim-name riscv-sim --cmodel medany --build-arch-abi "rv32imafc-ilp32f rv64imafdc-lp64d"

Before this patch the result is:
 riscv-sim/-march=rv32imafc/-mabi=ilp32f rv64imafdc/-mcmodel=medany    
After this patch,the result is:
riscv-sim/-march=rv32imafc/-mabi=ilp32f/-mcmodel=medany riscv-sim/-march=rv64imafdc/-mabi=lp64d/-mcmodel=medany
    
At the same time,there is small modification for Makefile.in,the parameters of build-arch-abi should be enclosed in double quotation marks. --build-arch-abi "$(NEWLIB_MULTILIB_NAMES)"