### PR TITLE
Add double quotation marks for build-arch-abi

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -96,7 +96,7 @@ GLIBC_CXX_FOR_TARGET ?= $(LINUX_TUPLE)-g++
 GLIBC_TARGET_BOARDS ?= $(shell $(srcdir)/scripts/generate_target_board \
   --sim-name riscv-sim \
   --cmodel $(shell echo @cmodel@ | cut -d '=' -f2) \
-  --build-arch-abi $(GLIBC_MULTILIB_NAMES) \
+  --build-arch-abi "$(GLIBC_MULTILIB_NAMES)" \
   --extra-test-arch-abi-flags-list "$(EXTRA_MULTILIB_TEST)")
 
 NEWLIB_CC_FOR_TARGET ?= $(NEWLIB_TUPLE)-gcc
@@ -104,13 +104,13 @@ NEWLIB_CXX_FOR_TARGET ?= $(NEWLIB_TUPLE)-g++
 NEWLIB_TARGET_BOARDS ?= $(shell $(srcdir)/scripts/generate_target_board \
   --sim-name riscv-sim \
   --cmodel $(shell echo @cmodel@ | cut -d '=' -f2) \
-  --build-arch-abi $(NEWLIB_MULTILIB_NAMES) \
+  --build-arch-abi "$(NEWLIB_MULTILIB_NAMES)" \
   --extra-test-arch-abi-flags-list "$(EXTRA_MULTILIB_TEST)")
 
 NEWLIB_NANO_TARGET_BOARDS ?= $(shell $(srcdir)/scripts/generate_target_board \
   --sim-name riscv-sim-nano \
   --cmodel $(shell echo @cmodel@ | cut -d '=' -f2) \
-  --build-arch-abi $(NEWLIB_MULTILIB_NAMES) \
+  --build-arch-abi "$(NEWLIB_MULTILIB_NAMES)" \
   --extra-test-arch-abi-flags-list "$(EXTRA_MULTILIB_TEST)")
 NEWLIB_CC_FOR_MULTILIB_INFO := $(NEWLIB_CC_FOR_TARGET)
 


### PR DESCRIPTION
In order to generate target board info for multilib, the parameters of build-arch-abi should be enclosed in double quotation marks. And the the python script generate_target_board will process it correctly