### PR TITLE
Handle multilib config correctly

### DIFF
--- a/scripts/generate_target_board
+++ b/scripts/generate_target_board
@@ -43,6 +43,26 @@ def generate_one_target_board(arch_abi, flags, options):
   return "{0}/-march={1}/-mabi={2}/-mcmodel={3}/{4}".format(
     options.sim_name, arch, abi, options.cmodel, flags)
 
+def gen_list(arch_abi_list, options):
+  target_board_list = []
+  extra_test_list = arch_abi_list
+
+  for extra_test in extra_test_list:
+    idx = extra_test.find(":")
+
+    if idx == -1:
+      one_target_board = generate_one_target_board(extra_test, "", options)
+      target_board_list.append(one_target_board)
+    else:
+      arch_abi = extra_test[:idx]
+      flags = extra_test[idx + 1:]
+
+      for flag in flags.split(","):
+        one_target_board = generate_one_target_board(arch_abi, flag, options)
+        target_board_list.append(one_target_board)
+
+  return target_board_list
+
 def main(argv):
   options = parse_options(argv)
 
@@ -50,26 +70,11 @@ def main(argv):
     print ("The --sim-name and/or --build-arch-abi cannot be empty or null.")
     return
 
-  target_board_list = [
-    generate_one_target_board(options.build_arch_abi, "", options)
-  ]
+  target_board_list = gen_list(options.build_arch_abi.split(" "), options)
 
   if options.extra_test_arch_abi_flags_list:
     extra_test_list = options.extra_test_arch_abi_flags_list.split (";")
-
-    for extra_test in extra_test_list:
-      idx = extra_test.find(":")
-
-      if idx == -1:
-        one_target_board = generate_one_target_board(extra_test, "", options)
-        target_board_list.append(one_target_board)
-      else:
-        arch_abi = extra_test[:idx]
-        flags = extra_test[idx + 1:]
-
-        for flag in flags.split(","):
-          one_target_board = generate_one_target_board(arch_abi, flag, options)
-          target_board_list.append(one_target_board)
+    target_board_list += gen_list(extra_test_list, options)
 
   print(' '.join(target_board_list))
 


### PR DESCRIPTION
`--build-arch-abi` may give more than one arch/abi pair if multilib enabled, but we don't handle that well before...

Before the patch:
```bash
$ scripts/generate_target_board --sim-name riscv-sim --cmodel medlow \
  --build-arch-abi "rv32imac-ilp32 rv32imafdc-ilp32d rv64imac-lp64 rv64imafdc-lp64d" \
  --extra-test-arch-abi-flags-list ""
riscv-sim/-march=rv32imac/-mabi=ilp32 rv32imafdc/-mcmodel=medlow
```

After the patch:
```bash
$ scripts/generate_target_board --sim-name riscv-sim --cmodel medlow \
  --build-arch-abi "rv32imac-ilp32 rv32imafdc-ilp32d rv64imac-lp64 rv64imafdc-lp64d" \
  --extra-test-arch-abi-flags-list ""
riscv-sim/-march=rv32imac/-mabi=ilp32/-mcmodel=medlow riscv-sim/-march=rv32imafdc/-mabi=ilp32d/-mcmodel=medlow riscv-sim/-march=rv64imac/-mabi=lp64/-mcmodel=medlow riscv-sim/-march=rv64imafdc/-mabi=lp64d/-mcmodel=medlow
```