### PR TITLE
Bump GCC to 14[.1.0] - addresses #1471

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "gcc"]
 	path = gcc
 	url = https://gcc.gnu.org/git/gcc.git
-	branch = releases/gcc-13
+	branch = releases/gcc-14
 [submodule "glibc"]
 	path = glibc
 	url = https://sourceware.org/git/glibc.git


### PR DESCRIPTION
Bump GCC to 14[.1.0] - addresses this issue:

* https://github.com/riscv-collab/riscv-gnu-toolchain/issues/1471

Looking at the previous GCC version bump PR:

* https://github.com/riscv-collab/riscv-gnu-toolchain/pull/1341

I'm not sure if it's sufficient to update just the submodule commit and the `.gitmodules` file or if further changes are also required - e.g. to test suite exclusion lists etc.? I guess the results of the CI test suite runs may clarify?