### PR TITLE
Add --enable-default-pie option and disable that by default

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -15,6 +15,7 @@ PK_SRCDIR := @with_pk_src@
 LLVM_SRCDIR := @with_llvm_src@
 DEJAGNU_SRCDIR := @with_dejagnu_src@
 DEBUG_INFO := @debug_info@
+ENABLE_DEFAULT_PIE := @enable_default_pie@
 DEJAGNU_SRCDIR := @with_dejagnu_src@
 
 SIM ?= @WITH_SIM@
@@ -470,6 +471,7 @@ stamps/build-gcc-linux-stage1: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-binutil
 		--disable-nls \
 		--disable-bootstrap \
 		--src=$(gccsrcdir) \
+		$(ENABLE_DEFAULT_PIE) \
 		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \
 		$(WITH_ABI) \
@@ -506,6 +508,7 @@ stamps/build-gcc-linux-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) $(addprefix stamps/b
 		--disable-nls \
 		--disable-bootstrap \
 		--src=$(gccsrcdir) \
+		$(ENABLE_DEFAULT_PIE) \
 		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \
 		$(WITH_ABI) \
@@ -814,6 +817,7 @@ stamps/build-gcc-musl-stage1: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-binutils
 		--disable-nls \
 		--disable-bootstrap \
 		--src=$(gccsrcdir) \
+		$(ENABLE_DEFAULT_PIE) \
 		$(GCC_CHECKING_FLAGS) \
 		--disable-multilib \
 		$(WITH_ABI) \
@@ -883,6 +887,7 @@ stamps/build-gcc-musl-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-musl-lin
 		--disable-nls \
 		--disable-bootstrap \
 		--src=$(gccsrcdir) \
+		$(ENABLE_DEFAULT_PIE) \
 		$(GCC_CHECKING_FLAGS) \
 		--disable-multilib \
 		$(WITH_ABI) \

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ The musl compiler (riscv64-unknown-linux-musl-) will only be able to target
 The `--enable-multilib` flag therefore does not actually enable multilib support
 for musl libc.
 
+Linux toolchain has an additional option `--enable-default-pie` to control the
+default PIE enablement for GCC, which is disable by default.
+
 ### Troubleshooting Build Problems
 
 Builds work best if installing into an empty directory.  If you build a

--- a/configure
+++ b/configure
@@ -619,6 +619,7 @@ WITH_ISA_SPEC
 WITH_TUNE
 WITH_ABI
 WITH_ARCH
+enable_default_pie
 debug_info
 default_target
 FETCHER
@@ -681,6 +682,7 @@ ac_user_opts='
 enable_option_checking
 enable_linux
 enable_debug_info
+enable_default_pie
 with_arch
 with_abi
 with_tune
@@ -1335,6 +1337,8 @@ Optional Features:
                           [--disable-linux]
   --enable-debug-info     build glibc/musl/newlibc/libgcc with debug
                           information
+  --enable-default-pie    build linux toolchain with default PIE
+                          [--enable-default-pie]
   --enable-multilib       build both RV32 and RV64 runtime libraries (only
                           RV64 for musl libc) [--disable-multilib]
   --enable-gcc-checking   Enable gcc internal checking, it will make gcc very
@@ -3329,6 +3333,24 @@ else
   debug_info="-g"
 
 fi
+
+# Check whether --enable-default-pie was given.
+if test "${enable_default_pie+set}" = set; then :
+  enableval=$enable_default_pie;
+else
+  enable_default_pie=no
+
+fi
+
+
+if test "x$enable_default_pie" != xyes; then :
+  enable_default_pie="--disable-default-pie"
+
+else
+  enable_default_pie="--enable-default-pie"
+
+fi
+
 
 
 # Check whether --with-arch was given.

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,18 @@ AS_IF([test "x$enable_debug_info" != xyes],
 	[AC_SUBST(debug_info, "")],
 	[AC_SUBST(debug_info, "-g")])
 
+AC_ARG_ENABLE(default-pie,
+        [AS_HELP_STRING([--enable-default-pie],
+		[build linux toolchain with default PIE @<:@--enable-default-pie@:>@])],
+        [],
+        [enable_default_pie=no]
+        )
+
+AS_IF([test "x$enable_default_pie" != xyes],
+	[AC_SUBST(enable_default_pie, "--disable-default-pie")],
+	[AC_SUBST(enable_default_pie, "--enable-default-pie")])
+
+
 AC_ARG_WITH(arch,
 	[AS_HELP_STRING([--with-arch=rv64imafdc],
 		[Sets the base RISC-V ISA, defaults to rv64imafdc])],


### PR DESCRIPTION
`--enable-default-pie` is used to control the default PIE enablement for Linux GCC, which is enabled by default, similar to most Linux distributions.

NOTE: baremetal toolchain isn't affected by this option.