### PR TITLE
[glibc]: Specify locale-archive search path

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -420,7 +420,7 @@ endif
 	$(eval $@_LIBDIRSUFFIX := $(if $($@_ABI),$(shell echo $($@_ARCH) | sed 's/.*rv\([0-9]*\).*/\1/')/$($@_ABI),))
 	$(eval $@_XLEN := $(if $($@_ABI),$(shell echo $($@_ARCH) | sed 's/.*rv\([0-9]*\).*/\1/'),$(XLEN)))
 	$(eval $@_CFLAGS := $(if $($@_ABI),-march=$($@_ARCH) -mabi=$($@_ABI),))
-	$(eval $@_LIBDIROPTS := $(if $@_LIBDIRSUFFIX,--libdir=/usr/lib$($@_LIBDIRSUFFIX) libc_cv_slibdir=/lib$($@_LIBDIRSUFFIX) libc_cv_rtlddir=/lib,))
+	$(eval $@_LIBDIROPTS := $(if $@_LIBDIRSUFFIX,--libdir=/usr/lib$($@_LIBDIRSUFFIX) libc_cv_slibdir=/lib$($@_LIBDIRSUFFIX) libc_cv_rtlddir=/lib libc_cv_complocaledir=/usr/lib/locale,))
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && \


### PR DESCRIPTION
According to glibc documentation
```locale-archive which is generally installed as /usr/lib/locale/locale-archive```

For new glibc versions (2.38+) you can face with problem: ```locale-archive``` are searched for in ```/usr/lib64/lp64d/locale``` folder

To reproduce: compile test.c with call to ```setlocale(LC_ALL, "")``` and run ```strace```

Finally, to search for locale-archive in default folder we need to extra specify ```libc_cv_complocaledir``` in order to overwrite ```Makeconfig:complocaledir=${libdir}/locale```.