### PR TITLE
Add filling-one for tail/mask agnostic on qemu

### DIFF
--- a/scripts/march-to-cpu-opt
+++ b/scripts/march-to-cpu-opt
@@ -163,6 +163,10 @@ def print_qemu_cpu():
 
     if CPU_OPTIONS['vlen']:
         cpu_options.append("vlen={0}".format(CPU_OPTIONS['vlen']))
+        # Enable fill one semantic for tail/mask agnostic, this could discover
+        # more potential bug.
+        cpu_options.append("rvv_ta_all_1s=true")
+        cpu_options.append("rvv_ma_all_1s=true")
 
     disable_all_fd = False
     for ext in CPU_OPTIONS['extensions']:


### PR DESCRIPTION
Default behavior of qemu is treat tail/mask agnostic as tail/mask undisturbed, and this may hidding some problem, one example is
[PR115725](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115725) for GCC.