### PR TITLE
Override CLANG_DEFAULT_OPENMP_RUNTIME to libgomp

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -966,6 +966,7 @@ stamps/build-llvm-linux: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BIN
 	    cmake $(LLVM_SRCDIR)/llvm \
 	    -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR) \
 	    -DCMAKE_BUILD_TYPE=Release \
+	    -DCLANG_DEFAULT_OPENMP_RUNTIME=libgomp \
 	    -DLLVM_TARGETS_TO_BUILD="RISCV" \
 	    -DLLVM_ENABLE_PROJECTS="clang;lld" \
 	    -DLLVM_ENABLE_RUNTIMES="compiler-rt;libcxx;libcxxabi;libunwind" \


### PR DESCRIPTION
For Clang/LLVM, the default OpenMP library is `libomp.so`.

However, we don't build openmp library, which will cause a linker error:
```
riscv64-unknown-linux-gnu-ld: cannot find -lomp: No such file or directory
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

There are some issues for building openomp project in LLVM (please see also #1512), but the support in GNU toolchain is complete. So we change the default openomp runtime to `libgomp` to make Clang not complain.