### PR TITLE
fix: shared lib suffix LLVMgold macOS

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -20,6 +20,10 @@ DEJAGNU_SRCDIR := @with_dejagnu_src@
 
 SIM ?= @WITH_SIM@
 
+# Shared lib suffix
+IS_DARWIN := $(shell uname -s | grep Darwin)
+SHARED_LIB_SUFFIX := $(if $(IS_DARWIN),dylib,so)
+
 ifeq ($(srcdir)/gcc,$(GCC_SRCDIR))
 # We need a relative source dir for the gcc configure, to make msys2 mingw64
 # builds work.  Mayberelsrcdir is relative if a relative path was used to run
@@ -1049,7 +1053,7 @@ stamps/build-llvm-linux: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BIN
 	    $(MAKE) -C $(notdir $@)/openmp-static install; \
 	fi
 	cp $(notdir $@)/lib/riscv$(XLEN)-unknown-linux-gnu/libc++* $(SYSROOT)/lib
-	cp $(notdir $@)/lib/LLVMgold.so  $(INSTALL_DIR)/lib
+	cp $(notdir $@)/lib/LLVMgold.$(SHARED_LIB_SUFFIX) $(INSTALL_DIR)/lib
 	cd $(INSTALL_DIR)/bin && ln -s -f clang $(LINUX_TUPLE)-clang && ln -s -f clang++ $(LINUX_TUPLE)-clang++
 	mkdir -p $(dir $@) && touch $@
 
@@ -1069,7 +1073,7 @@ stamps/build-llvm-newlib: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BI
 	    -DLLVM_PARALLEL_LINK_JOBS=4
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
-	cp $(notdir $@)/lib/LLVMgold.so  $(INSTALL_DIR)/lib
+	cp $(notdir $@)/lib/LLVMgold.$(SHARED_LIB_SUFFIX) $(INSTALL_DIR)/lib
 	cd $(INSTALL_DIR)/bin && ln -s -f clang $(NEWLIB_TUPLE)-clang && \
 	    ln -s -f clang++ $(NEWLIB_TUPLE)-clang++
 	mkdir -p $(dir $@) && touch $@


### PR DESCRIPTION
Fix the shared lib suffix on macOS for LLVMgold to use .dylib instead of .so