### PR TITLE
Bump binutils from 2.43 to 2.43.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "binutils"]
 	path = binutils
 	url = https://sourceware.org/git/binutils-gdb.git
-	branch = binutils-2_42-branch
+	branch = binutils-2_43-branch
 [submodule "gcc"]
 	path = gcc
 	url = https://gcc.gnu.org/git/gcc.git


### PR DESCRIPTION
Test results (with --enable-multilib):
```
               ========= Summary of gcc testsuite =========
                            | # of unexpected case / # of unique unexpected case
                            |          gcc |          g++ |     gfortran |
   rv32imac/  ilp32/ medlow |    0 /     0 |    0 /     0 |    0 /     0 |
 rv32imafdc/ ilp32d/ medlow |    0 /     0 |    0 /     0 |    0 /     0 |
   rv64imac/   lp64/ medlow |    0 /     0 |    0 /     0 |    0 /     0 |
 rv64imafdc/  lp64d/ medlow |    0 /     0 |    0 /     0 |    0 /     0 |
```