### PR TITLE
Generate configuration files for clang/clang++

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1204,8 +1204,8 @@ stamps/build-llvm-linux: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BIN
 	cp $(notdir $@)/lib/riscv$(XLEN)-unknown-linux-gnu/libc++* $(SYSROOT)/lib
 	cp $(notdir $@)/lib/LLVMgold.$(SHARED_LIB_SUFFIX) $(INSTALL_DIR)/lib
 	cd $(INSTALL_DIR)/bin && ln -s -f clang $(LINUX_TUPLE)-clang && ln -s -f clang++ $(LINUX_TUPLE)-clang++
-	cd $(INSTALL_DIR)/bin && echo "-march=${MARCH} -mabi=${MABI} -mtune=${MTUNE}" >> $(LINUX_TUPLE)-clang.cfg
-	cd $(INSTALL_DIR)/bin && echo "-march=${MARCH} -mabi=${MABI} -mtune=${MTUNE}" >> $(LINUX_TUPLE)-clang++.cfg
+	echo "-march=${MARCH} -mabi=${MABI} -mtune=${MTUNE}" > $(INSTALL_DIR)/bin/$(LINUX_TUPLE)-clang.cfg
+	echo "-march=${MARCH} -mabi=${MABI} -mtune=${MTUNE}" > $(INSTALL_DIR)/bin/$(LINUX_TUPLE)-clang++.cfg
 	mkdir -p $(dir $@) && touch $@
 
 stamps/build-llvm-newlib: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) \
@@ -1227,8 +1227,8 @@ stamps/build-llvm-newlib: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BI
 	cp $(notdir $@)/lib/LLVMgold.$(SHARED_LIB_SUFFIX) $(INSTALL_DIR)/lib
 	cd $(INSTALL_DIR)/bin && ln -s -f clang $(NEWLIB_TUPLE)-clang && \
 	    ln -s -f clang++ $(NEWLIB_TUPLE)-clang++
-	cd $(INSTALL_DIR)/bin && echo "-march=${MARCH} -mabi=${MABI} -mtune=${MTUNE}" >> $(LINUX_TUPLE)-clang.cfg \
-	cd $(INSTALL_DIR)/bin && echo "-march=${MARCH} -mabi=${MABI} -mtune=${MTUNE}" >> $(LINUX_TUPLE)-clang++.cfg
+	echo "-march=${MARCH} -mabi=${MABI} -mtune=${MTUNE}" > $(INSTALL_DIR)/bin/$(NEWLIB_TUPLE)-clang.cfg
+	echo "-march=${MARCH} -mabi=${MABI} -mtune=${MTUNE}" > $(INSTALL_DIR)/bin/$(NEWLIB_TUPLE)-clang++.cfg
 	mkdir -p $(dir $@) && touch $@
 
 stamps/build-dejagnu: $(DEJAGNU_SRCDIR) $(DEJAGNU_SRC_GIT) $(PREPARATION_STAMP)

--- a/Makefile.in
+++ b/Makefile.in
@@ -81,6 +81,9 @@ XLEN := $(shell echo $(WITH_ARCH) | tr A-Z a-z | sed 's/.*rv\([0-9]*\).*/\1/')
 ifneq ($(XLEN),32)
 	XLEN := 64
 endif
+MARCH := $(shell echo $(WITH_ARCH) | tr A-Z a-z | sed 's/.*--with-arch=\(.*\).*/\1/')
+MABI := $(shell echo $(WITH_ABI) | tr A-Z a-z | sed 's/.*--with-abi=\(.*\).*/\1/')
+MTUNE := $(shell echo $(WITH_TUNE) | tr A-Z a-z | sed 's/.*--with-tune=\(.*\).*/\1/')
 
 make_tuple = riscv$(1)-unknown-$(2)
 LINUX_TUPLE  ?= $(call make_tuple,$(XLEN),linux-gnu)
@@ -1201,6 +1204,8 @@ stamps/build-llvm-linux: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BIN
 	cp $(notdir $@)/lib/riscv$(XLEN)-unknown-linux-gnu/libc++* $(SYSROOT)/lib
 	cp $(notdir $@)/lib/LLVMgold.$(SHARED_LIB_SUFFIX) $(INSTALL_DIR)/lib
 	cd $(INSTALL_DIR)/bin && ln -s -f clang $(LINUX_TUPLE)-clang && ln -s -f clang++ $(LINUX_TUPLE)-clang++
+	cd $(INSTALL_DIR)/bin && echo "-march=${MARCH} -mabi=${MABI} -mtune=${MTUNE}" >> $(LINUX_TUPLE)-clang.cfg
+	cd $(INSTALL_DIR)/bin && echo "-march=${MARCH} -mabi=${MABI} -mtune=${MTUNE}" >> $(LINUX_TUPLE)-clang++.cfg
 	mkdir -p $(dir $@) && touch $@
 
 stamps/build-llvm-newlib: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) \
@@ -1222,6 +1227,8 @@ stamps/build-llvm-newlib: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BI
 	cp $(notdir $@)/lib/LLVMgold.$(SHARED_LIB_SUFFIX) $(INSTALL_DIR)/lib
 	cd $(INSTALL_DIR)/bin && ln -s -f clang $(NEWLIB_TUPLE)-clang && \
 	    ln -s -f clang++ $(NEWLIB_TUPLE)-clang++
+	cd $(INSTALL_DIR)/bin && echo "-march=${MARCH} -mabi=${MABI} -mtune=${MTUNE}" >> $(LINUX_TUPLE)-clang.cfg \
+	cd $(INSTALL_DIR)/bin && echo "-march=${MARCH} -mabi=${MABI} -mtune=${MTUNE}" >> $(LINUX_TUPLE)-clang++.cfg
 	mkdir -p $(dir $@) && touch $@
 
 stamps/build-dejagnu: $(DEJAGNU_SRCDIR) $(DEJAGNU_SRC_GIT) $(PREPARATION_STAMP)


### PR DESCRIPTION
For GCC, the default `-march`/`-mabi`/`-mtune` can be specified via configuring with `--with-arch`, `--with-abi` and `--with-tune`. But these options won't take affect for Clang/LLVM.

For Clang/LLVM, we can use configuration files[1] to specify default options for different tools/targets. So we automatically generate two configuration files (for `clang` and `clang++`) and specify these options in them.

References:
[1] https://clang.llvm.org/docs/UsersManual.html#configuration-files