### PR TITLE
Convert shared  build of LLVM OpenMP to in-tree

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -80,6 +80,8 @@ EXTRA_MULTILIB_TEST := @extra_multilib_test@
 XLEN := $(shell echo $(WITH_ARCH) | tr A-Z a-z | sed 's/.*rv\([0-9]*\).*/\1/')
 ifneq ($(XLEN),32)
 	XLEN := 64
+	LLVM_OPENMP := openmp
+	LLVM_OPENMP_CMAKE_FLAGS := -DRUNTIMES_CMAKE_ARGS="-DLIBOMP_OMPD_SUPPORT=OFF;-DLIBOMP_ARCHER_SUPPORT=OFF;-DOPENMP_ENABLE_LIBOMPTARGET=OFF"
 endif
 
 make_tuple = riscv$(1)-unknown-$(2)
@@ -1148,36 +1150,18 @@ stamps/build-llvm-linux: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BIN
 	    -DCMAKE_BUILD_TYPE=Release \
 	    -DLLVM_TARGETS_TO_BUILD="RISCV" \
 	    -DLLVM_ENABLE_PROJECTS="clang;lld" \
-	    -DLLVM_ENABLE_RUNTIMES="compiler-rt;libcxx;libcxxabi;libunwind" \
+	    -DLLVM_ENABLE_RUNTIMES="compiler-rt;libcxx;libcxxabi;libunwind;$(LLVM_OPENMP)" \
+	    $(LLVM_OPENMP_CMAKE_FLAGS) \
 	    -DLLVM_DEFAULT_TARGET_TRIPLE="$(LINUX_TUPLE)" \
 	    -DDEFAULT_SYSROOT="../sysroot" \
-	    -DLLVM_RUNTIME_TARGETS=$(call make_tuple,$(XLEN),linux-gnu) \
+	    -DLLVM_RUNTIME_TARGETS=default \
 	    -DLLVM_INSTALL_TOOLCHAIN_ONLY=On \
 	    -DLLVM_BINUTILS_INCDIR=$(BINUTILS_SRCDIR)/include \
 	    -DLLVM_PARALLEL_LINK_JOBS=4
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
-	# Build shared/static OpenMP libraries on RV64.
+	# Build static OpenMP libraries on RV64.
 	if test $(XLEN) -eq 64; then \
-	    mkdir $(notdir $@)/openmp-shared; \
-	    cmake -S$(LLVM_SRCDIR)/openmp \
-	        -B$(notdir $@)/openmp-shared \
-	        -DCMAKE_INSTALL_PREFIX=$(SYSROOT) \
-	        -DCMAKE_C_COMPILER=$(INSTALL_DIR)/bin/clang \
-	        -DCMAKE_CXX_COMPILER=$(INSTALL_DIR)/bin/clang++ \
-	        -DOPENMP_ENABLE_LIBOMPTARGET=Off \
-	        -DCMAKE_BUILD_TYPE=Release \
-	        -DLIBOMP_ARCH=riscv64 \
-	        -DLIBOMP_HAVE_WARN_SHARED_TEXTREL_FLAG=On \
-	        -DLIBOMP_HAVE_AS_NEEDED_FLAG=On \
-	        -DLIBOMP_HAVE_VERSION_SCRIPT_FLAG=On \
-	        -DLIBOMP_HAVE_STATIC_LIBGCC_FLAG=On \
-	        -DLIBOMP_HAVE_Z_NOEXECSTACK_FLAG=On \
-	        -DDISABLE_OMPD_GDB_PLUGIN=On \
-	        -DLIBOMP_OMPD_GDB_SUPPORT=Off \
-	        -DLIBOMP_ENABLE_SHARED=On; \
-	    $(MAKE) -C $(notdir $@)/openmp-shared; \
-	    $(MAKE) -C $(notdir $@)/openmp-shared install; \
 	    mkdir $(notdir $@)/openmp-static; \
 	    cmake -S$(LLVM_SRCDIR)/openmp \
 	        -B$(notdir $@)/openmp-static \


### PR DESCRIPTION
LLVM OpenMP can't bed built both ways at the same time, also in-tree build needs to avoid 32-bit for now as well.