### PR TITLE
CI: Drop Ubuntu 20.04 and add Ubuntu 24.04

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:     [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os:     [ubuntu-22.04, ubuntu-24.04]
         mode:   [newlib, linux, musl]
         target: [rv32gc-ilp32d, rv64gc-lp64d]
         compiler: [gcc, llvm]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:     [ubuntu-20.04, ubuntu-22.04]
+        os:     [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
         mode:   [newlib, linux, musl]
         target: [rv32gc-ilp32d, rv64gc-lp64d]
         compiler: [gcc, llvm]
@@ -50,7 +50,7 @@ jobs:
 
       - name: make report
         if: |
-          matrix.os == 'ubuntu-22.04'
+          matrix.os == 'ubuntu-24.04'
           && (matrix.mode == 'linux' || matrix.mode == 'newlib')
           && matrix.compiler == 'gcc'
         run: |
@@ -88,7 +88,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:     [ubuntu-22.04]
+        os:     [ubuntu-24.04]
         mode:   [newlib]
         target: [rv64gc-lp64d]
         sim:    [spike]
@@ -121,7 +121,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:     [ubuntu-22.04]
+        os:     [ubuntu-24.04]
         mode:   [newlib, linux]
         target: [rv64gc-lp64d]
     steps:

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:       [ubuntu-20.04, ubuntu-22.04]
+        os:       [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
         mode:     [newlib, linux, musl]
         target:   [rv32gc-ilp32d, rv64gc-lp64d]
         compiler: [gcc, llvm]

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:       [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os:       [ubuntu-22.04, ubuntu-24.04]
         mode:     [newlib, linux, musl]
         target:   [rv32gc-ilp32d, rv64gc-lp64d]
         compiler: [gcc, llvm]


### PR DESCRIPTION
We have build issues in Ubuntu 20.04 with QEMU, because of an outdated
host dependency (glib2 is 2.64.6 but >= 2.66 is required).

Ubuntu LTS releases have a standard support lifecycle of 5 years,
so Ubuntu 20.04 support will be ending in about 6 months.

This PR avoids further workarounds by replacing Ubuntu 20.04 by Ubuntu 24.04.