### PR TITLE
Enable RV32 build of Linux/musl toolchain

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,8 +19,6 @@ jobs:
         compiler: [gcc, llvm]
         exclude:
           - mode: musl
-            target: rv32gc-ilp32d
-          - mode: musl
             compiler: llvm
     steps:
       - name: Remove unneeded frameworks to recover disk space

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -54,8 +54,6 @@ jobs:
         compiler: [gcc, llvm]
         exclude:
           - mode: musl
-            target: rv32gc-ilp32d
-          - mode: musl
             compiler: llvm
     steps:
       - name: Remove unneeded frameworks to recover disk space

--- a/Makefile.in
+++ b/Makefile.in
@@ -141,13 +141,7 @@ GCC_CHECKING_FLAGS := $(GCC_CHECKING_FLAGS) --enable-werror-always
 endif
 newlib: stamps/build-gcc-newlib-stage2
 linux: stamps/build-gcc-linux-stage2
-ifneq (,$(findstring riscv32,$(MUSL_TUPLE)))
-.PHONY: musl
-musl:
-	@echo "musl only supports 64bit builds." && exit 1
-else
 musl: stamps/build-gcc-musl-stage2
-endif
 uclibc: stamps/build-gcc-uclibc-stage2
 ifeq (@enable_gdb@,--enable-gdb)
 newlib: stamps/build-gdb-newlib

--- a/README.md
+++ b/README.md
@@ -100,11 +100,6 @@ systems.
 It will support the most common `-march`/`-mabi` options, which can be seen by
 using the `--print-multi-lib` flag on either cross-compiler.
 
-The musl compiler (riscv64-unknown-linux-musl-) will only be able to target
-64-bit systems due to limitations in the upstream musl architecture support.
-The `--enable-multilib` flag therefore does not actually enable multilib support
-for musl libc.
-
 Linux toolchain has an additional option `--enable-default-pie` to control the
 default PIE enablement for GCC, which is disable by default.
 

--- a/configure
+++ b/configure
@@ -1382,8 +1382,8 @@ Optional Features:
                           information
   --enable-default-pie    build linux toolchain with default PIE
                           [--enable-default-pie]
-  --enable-multilib       build both RV32 and RV64 runtime libraries (only
-                          RV64 for musl libc) [--disable-multilib]
+  --enable-multilib       build both RV32 and RV64 runtime libraries 
+                          [--disable-multilib]
   --enable-gcc-checking   Enable gcc internal checking, it will make gcc very
                           slow, only enable it when developing gcc
                           [--disable-gcc-checking]

--- a/configure.ac
+++ b/configure.ac
@@ -174,7 +174,7 @@ AS_IF([test "x$enable_multilib" != xno],
         [AC_SUBST(newlib_multilib_names,"$with_arch-$with_abi")])
 
 AS_IF([test "x$enable_multilib" != xno],
-        [AC_SUBST(musl_multilib_names,"rv64imac-lp64 rv64imafdc-lp64d")],
+        [AC_SUBST(musl_multilib_names,"rv32imac-ilp32 rv32imafdc-ilp32d rv64imac-lp64 rv64imafdc-lp64d")],
         [AC_SUBST(musl_multilib_names,"$with_arch-$with_abi")])
 
 AC_ARG_ENABLE(gcc-checking,


### PR DESCRIPTION
With musl having been bumped to v1.2.5 recently:

- https://github.com/riscv-collab/riscv-gnu-toolchain/pull/1568

it is now possible to enable the RV32 build of the Linux/musl toolchain.

- https://github.com/riscv-collab/riscv-gnu-toolchain/pull/1568#issuecomment-2401775800

This PR effectively removes the restrictions imposed by this commit:

- https://github.com/riscv-collab/riscv-gnu-toolchain/commit/629c67e0a93ec03edd3dfab60a2b8ad9c1768a2a

I have checked that the "normal" (`rv64gc/lp64d`) and RV32 (`rv32gc/ilp32d`) configuration/builds of the Linux/musl toolchain complete successfully. At the moment there is no support for running the GCC test suite against the resulting toolchains so no further testing has been done.

Notes:

1. I'm not sure what was the rationale for/purpose of this PR a long time (6 years!) ago given that, at the time, musl did not have RV32 support.

- https://github.com/riscv-collab/riscv-gnu-toolchain/pull/392

2. Even before this current PR `--enable-multilib` was being ignored due to this part of `Makefile.in` and this PR does not change this behaviour. Another PR can be done to deal with this if necessary.

- https://github.com/riscv-collab/riscv-gnu-toolchain/blob/071f07c9364856cdcf49dfee0c645f564305df52/Makefile.in#L910
- https://github.com/riscv-collab/riscv-gnu-toolchain/blob/071f07c9364856cdcf49dfee0c645f564305df52/Makefile.in#L934