### PR TITLE
Enable Linux/uClibc-ng toolchain build in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,11 +14,13 @@ jobs:
     strategy:
       matrix:
         os:     [ubuntu-22.04, ubuntu-24.04]
-        mode:   [newlib, linux, musl]
+        mode:   [newlib, linux, musl uclibc]
         target: [rv32gc-ilp32d, rv64gc-lp64d]
         compiler: [gcc, llvm]
         exclude:
           - mode: musl
+            compiler: llvm
+          - mode: uclibc
             compiler: llvm
     steps:
       - name: Remove unneeded frameworks to recover disk space
@@ -57,7 +59,7 @@ jobs:
       - name: recover space
         run: |
           sudo du -hs / 2> /dev/null || true
-          sudo rm -rf binutils dejagnu gcc gdb glibc llvm musl newlib pk qemu spike || true
+          sudo rm -rf binutils dejagnu gcc gdb glibc llvm musl newlib pk qemu spike uclibc-ng || true
           sudo du -hs / 2> /dev/null || true
 
       - name: tarball build
@@ -72,6 +74,8 @@ jobs:
               MODE="glibc";;
             "musl")
               MODE="musl";;
+            "uclibc")
+              MODE="uclibc-ng";;
             *)
               MODE="elf";;
           esac
@@ -159,6 +163,8 @@ jobs:
               MODE="glibc";;
             "musl")
               MODE="musl";;
+            "uclibc")
+              MODE="uclibc-ng";;
             *)
               MODE="elf";;
           esac

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os:     [ubuntu-22.04, ubuntu-24.04]
-        mode:   [newlib, linux, musl uclibc]
+        mode:   [newlib, linux, musl, uclibc]
         target: [rv32gc-ilp32d, rv64gc-lp64d]
         compiler: [gcc, llvm]
         exclude:

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -49,11 +49,14 @@ jobs:
     strategy:
       matrix:
         os:       [ubuntu-22.04, ubuntu-24.04]
-        mode:     [newlib, linux, musl]
+        mode:     [newlib, linux, musl, uclibc]
         target:   [rv32gc-ilp32d, rv64gc-lp64d]
         compiler: [gcc, llvm]
         exclude:
           - mode: musl
+            compiler: llvm
+
+          - mode: uclibc
             compiler: llvm
     steps:
       - name: Remove unneeded frameworks to recover disk space
@@ -89,7 +92,7 @@ jobs:
       - name: recover space
         run: |
           sudo du -hs / 2> /dev/null || true
-          sudo rm -rf binutils dejagnu gcc gdb glibc llvm musl newlib pk qemu spike || true
+          sudo rm -rf binutils dejagnu gcc gdb glibc llvm musl newlib pk qemu spike uclibc-ng || true
           sudo du -hs / 2> /dev/null || true
 
       - name: tarball build
@@ -104,6 +107,8 @@ jobs:
               MODE="glibc";;
             "musl")
               MODE="musl";;
+            "uclibc")
+              MODE="uclibc-ng";;
             *)
               MODE="elf";;
           esac


### PR DESCRIPTION
See:

- See https://github.com/riscv-collab/riscv-gnu-toolchain/issues/1566

Notes:

1. I don't think that I can test these changes locally so am creating the PR on the assumption that they will be sanity checked server side.
2. While "ulibc" is used across riscv-gnu-toolchain to refer to this toolchain variant, it is actually uClibc-ng based and not based on the original uClibc.
3. For this reason I have used "uclibc-ng" when naming the build tarball artifact but I don't know if the dash in this string will be in any way problematic or inconsistent with the existing naming convention?
4. I may need to rebase this if/when other pending PRs that I have submitted today are merged.
5. I am assuming that, like the Linux/musl toolchain variant. LLVM is also not an option for the uClibc-ng toolchain?
6. As ever, I'm open to constructive feedback and comments. :-)