### PR TITLE
CI/CD: Bump download-artifact to v4

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -159,7 +159,7 @@ jobs:
           prerelease: true
 
       - name: Download Built Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           path: ${{ env.ARTIFACTS_DIR }}
 
@@ -200,7 +200,7 @@ jobs:
     name: upload ${{ matrix.artifact }}
     steps:
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.artifact }}
 


### PR DESCRIPTION
The create-release CI/CD step is currently failing with the error:
  This request has been automatically failed because it uses a deprecated
  version of `actions/download-artifact: v2`

Github deprecated download-artifact v2 and asks users to use v4 instead:
  https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

Let's do what's recommended to unbreak the release action.

The log of the failed release action can be found here:
  https://github.com/riscv-collab/riscv-gnu-toolchain/actions/runs/11301066455/job/31452733595#logs