### PR TITLE
CI: Use merge time for activity check

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -16,7 +16,7 @@ jobs:
         id: activity_check
         run:   |
           curl -sL https://api.github.com/repos/$GITHUB_REPOSITORY/commits | jq -r '[.[]][0]' > $HOME/commit.json
-          date="$(jq -r '.commit.author.date' $HOME/commit.json)"
+          date="$(jq -r '.commit.committer.date' $HOME/commit.json)"
           timestamp=$(date --utc -d "$date" +%s)
           author="$(jq -r '.commit.author.name' $HOME/commit.json)"
           url="$(jq -r '.html_url' $HOME/commit.json)"


### PR DESCRIPTION
The activity check of the nightly release pipeline extracts the field 'commit.author.date' from the top commit to decide if commit was added in the last 24 hours. However, unless PRs are reviewed and merged within 24 hours this activity check will fail. Using the date of the merge instead leads to a more robust activity check.

To give a concrete example, here are the top lines of today's commit log:

```
{
  "sha": "a14abe3265ae8bd3ce463aefa4645bd376d08e5a",
  "node_id": "C_kwDOAWrbKtoAKGExNGFiZTMyNjVhZThiZDNjZTQ2M2FlZmE0NjQ1YmQzNzZkMDhlNWE",
  "commit": {
    "author": {
      "name": "Christoph Müllner",
      "email": "christoph.muellner@vrull.eu",
      "date": "2024-10-12T22:54:57Z"
    },
    "committer": {
      "name": "Christoph Müllner",
      "email": "christophm30@gmail.com",
      "date": "2024-10-16T08:08:11Z"
    },
[...]
```

The existing code extracts the following time:
```
$ jq -r '.commit.author.date' commit.json
2024-10-12T22:54:57Z
```

The code change in this PR changes this to the following:
```
$ jq -r '.commit.committer.date' commit.json
2024-10-16T08:08:11Z
```