### PR TITLE
fix NEWLIB_MULTILIB_NAMES in Makefile

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -74,7 +74,7 @@ ifeq ($(MULTILIB_GEN),)
 NEWLIB_MULTILIB_NAMES := @newlib_multilib_names@
 GCC_MULTILIB_FLAGS := $(MULTILIB_FLAGS)
 else
-NEWLIB_MULTILIB_NAMES := $(shell echo "$(MULTILIB_GEN)" | $(SED) 's/;/\n/g' | $(SED) '/^$$/d' | $(AWK) '{split($$0,a,"-"); printf "%s-%s ", a[1],a[2]}')
+NEWLIB_MULTILIB_NAMES := $(shell echo "$(MULTILIB_GEN)" | $(SED) 's/;/\n/g' | $(SED) '/^$$/d' | $(AWK) '{split($$0,a,"-"); printf "%s-%s", (NR==1?a[1]:" "a[1]),a[2]}')
 GCC_MULTILIB_FLAGS := $(MULTILIB_FLAGS) --with-multilib-generator="$(MULTILIB_GEN)"
 endif
 GLIBC_MULTILIB_NAMES := @glibc_multilib_names@


### PR DESCRIPTION
The NEWLIB_MULTILIB_NAMES generated in makefile for MULTILIB_GEN may contain space at the end, which cause the generate_target_board script to crash.