### PR TITLE
CI/CD: Bump upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,7 +81,7 @@ jobs:
           esac
           echo "TOOLCHAIN_NAME=riscv$BITS-$MODE-${{ matrix.os }}-${{ matrix.compiler }}-nightly" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}
           path: riscv.tar.gz
@@ -170,7 +170,7 @@ jobs:
           esac
           echo "TOOLCHAIN_NAME=riscv$BITS-$MODE-${{ matrix.os }}-multilib-nightly" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}
           path: riscv.tar.gz

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -114,7 +114,7 @@ jobs:
           esac
           echo "TOOLCHAIN_NAME=riscv$BITS-$MODE-${{ matrix.os }}-${{ matrix.compiler }}-nightly" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}
           path: riscv.tar.gz


### PR DESCRIPTION
We recently updated the download-artifact action to v4, because earlier versions were deprecated and stopped working.

Now we ran into the situation, that the release pipeline broke, because no toolchains are found by the download-artifact action ("Found 0 artifact(s)" although all toolchain builds succeeded and the resulting toolchain was successfully archived and uploaded).

Looking into the documention of download-artifact@v4 shows the issue: One of the breaking changes of download-artifact@v4 is "Downloading artifacts that were created from action/upload-artifact@v3 and below are not supported." ([1]). Our pipeline uses upload-artifact@v3, which is why they are not found later on.

Let's bump the upload-artifact action to v4 so that download-artifact@v4 will find the built artifacts again.

[1] https://github.com/actions/download-artifact?tab=readme-ov-file#v4---whats-new