### PR TITLE
Set `rv64gc` the default for `--with-arch` option.

### DIFF
--- a/configure
+++ b/configure
@@ -1398,7 +1398,7 @@ Optional Features:
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
-  --with-arch=rv64imafdc  Sets the base RISC-V ISA, defaults to rv64imafdc
+  --with-arch=rv64gc      Sets the base RISC-V ISA, defaults to rv64gc
   --with-abi=lp64d        Sets the base RISC-V ABI, defaults to lp64d
   --with-tune=rocket      Set the base RISC-V CPU, defaults to rocket
   --with-isa-spec=20191213
@@ -3993,7 +3993,7 @@ if test ${with_arch+y}
 then :
   withval=$with_arch;
 else $as_nop
-  with_arch=rv64imafdc
+  with_arch=rv64gc
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -80,10 +80,10 @@ AS_IF([test "x$enable_default_pie" != xyes],
 
 
 AC_ARG_WITH(arch,
-	[AS_HELP_STRING([--with-arch=rv64imafdc],
-		[Sets the base RISC-V ISA, defaults to rv64imafdc])],
+	[AS_HELP_STRING([--with-arch=rv64gc],
+		[Sets the base RISC-V ISA, defaults to rv64gc])],
 	[],
-	[with_arch=rv64imafdc]
+	[with_arch=rv64gc]
 	)
 
 AC_ARG_WITH(abi,


### PR DESCRIPTION
This PR updates the default option of `--with-arch` from `rv64imafdc` to `rv64gc`. In newer gcc versions, `gc` is equivalent to `imafdc_zicsr_zifencei`, which provides CSR instructions reading from and writing to CSRs(Zicsr) and fence instruction ensuring memory consistency between code and data(Zifencei).

Most Linux distributions (such as [Debian](https://wiki.debian.org/RISC-V) [Arch](https://[archriscv.felixc.at](https://archriscv.felixc.at/)/), [Gentoo](https://wiki.gentoo.org/wiki/Project:RISC-V) for RISC-V) use the `rv64gc` architecture when building RISC-V user space and kernel to ensure that system-level applications have the necessary instruction support now.

And most [RISC-V development boards](https://riscv.org/exchange/?_sft_exchange_category=board,hardware) now also set gc as their default supported arch. 