### PR TITLE
Add Arch Linux dependency package for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ the following command should suffice:
 
 On Arch Linux, executing the following command should suffice:
 
-    $ sudo pacman -Syyu python-pyelftools
+    $ sudo pacman -Syyu python-pyelftools python-sphinx python-sphinx_rtd_theme ninja
 
 If your distribution/OS does not have pyelftools package, you can install
 it using PIP.


### PR DESCRIPTION
When using `make report` command at Arch Linux, need to install the extra `python-sphinx python-sphinx_rtd_theme ninja` package.