### PR TITLE
Free up space in GitHub Actions Runners for remaining jobs

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -128,7 +128,14 @@ jobs:
       asset_matrix: ${{ steps.asset_names.outputs.asset_matrix }}
       datestamp: ${{ env.DATESTAMP }}
     steps:
-
+      - name: Remove unneeded frameworks to recover disk space
+        run: |
+          echo "-- Before --"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          echo "-- After --"
+          df -h
       - name:  Run Configuration Commands
         run: |
           DATESTAMP="$(date --utc '+%Y.%m.%d')"
@@ -199,6 +206,15 @@ jobs:
       matrix: ${{ fromJson( needs.create-release.outputs.asset_matrix ) }}
     name: upload ${{ matrix.artifact }}
     steps:
+
+      - name: Remove unneeded frameworks to recover disk space
+        run: |
+          echo "-- Before --"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          echo "-- After --"
+          df -h
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Attempt to resolve issue #1591 by creating more free space on the runner for the jobs that are failing.