### PR TITLE
Use Shallow Submodule Init to Reduce Clone Times

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:     [ubuntu-22.04, ubuntu-24.04]
         mode:   [newlib, linux, musl, uclibc]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,19 +24,38 @@ jobs:
           - mode: uclibc
             compiler: llvm
     steps:
-      - name: Remove unneeded frameworks to recover disk space
-        run: |
-          echo "-- Before --"
-          df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          echo "-- After --"
-          df -h
 
       - uses: actions/checkout@v4
 
       - name: install dependencies
-        run: sudo ./.github/setup-apt.sh
+        run: |
+          echo "-- Before --"
+          df -h
+          sudo apt-mark auto '.*' > /dev/null
+          sudo apt-get update
+          apt-get install -y --no-install-recommends \
+          ca-certificates \
+          # Configure Deps
+          autoconf \
+          gcc \
+          g++ \
+          gawk \
+          curl \
+          # Build Dependencies
+          make \
+          git \
+          texinfo \
+          bison \
+          flex \
+          bzip2 \
+          zlib1g-dev \
+          python3 \
+          libgmp-dev \
+          libmpfr-dev \
+          libexpat-dev
+          sudo apt-get autoremove
+          echo "-- After --"
+          df -h
 
       - name: build toolchain
         run: |

--- a/Makefile.in
+++ b/Makefile.in
@@ -347,7 +347,7 @@ endif
 $(srcdir)/%/.git:
 	cd $(srcdir) && \
 	flock `git rev-parse --git-dir`/config git submodule init $(dir $@) && \
-	flock `git rev-parse --git-dir`/config git submodule update --progress $(dir $@)
+	flock `git rev-parse --git-dir`/config git submodule update --progress --depth 1 $(dir $@)
 
 stamps/install-host-gcc: $(GCC_SRCDIR) $(GCC_SRC_GIT)
 	if test -f $</contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" = "true"; then cd $< && ./contrib/download_prerequisites; fi


### PR DESCRIPTION
Added `--depth 1` to the `git submodule update` command in `Makefile.in`.

To test I setup a docker image which built the repository with `./configure --prefix=/opt/riscv --with-arch=rv32gc --with-abi=ilp32d`. The image with this change was 14.77 GB where as the version without this change was 16.93 GB. That is a savings of 2.16 GB. This won't be a big deal for people developing in a stable environment where they only init the submodules once, but for cases where the build is happening in a container this is a big gain.

A different approach would be to populate the `shallow` property in `.gitmodules`. However, this approach only saves about 100MB, perhaps because the `shallow` property is not applied recursively.