### PR TITLE
CI/CD: Switch from gzip to XZ for archive compression

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,7 +63,7 @@ jobs:
           sudo du -hs / 2> /dev/null || true
 
       - name: tarball build
-        run: tar czvf riscv.tar.gz -C /opt/ riscv/
+        run: XZ_OPT="--threads=0 -6e" tar cJf riscv.tar.xz -C /opt/ riscv/
 
       - name: generate prebuilt toolchain name
         id:   toolchain-name-generator
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}
-          path: riscv.tar.gz
+          path: riscv.tar.xz
 
   test-sim:
     runs-on: ${{ matrix.os }}
@@ -152,7 +152,7 @@ jobs:
           sudo make report-${{ matrix.mode }} -j $(nproc)
 
       - name: tarball build
-        run: tar czvf riscv.tar.gz -C /opt/ riscv/
+        run: XZ_OPT="--threads=0 -6e" tar cJf riscv.tar.xz -C /opt/ riscv/
 
       - name: generate prebuilt toolchain name
         id:   toolchain-name-generator
@@ -173,4 +173,4 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}
-          path: riscv.tar.gz
+          path: riscv.tar.xz

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -96,7 +96,7 @@ jobs:
           sudo du -hs / 2> /dev/null || true
 
       - name: tarball build
-        run: tar czvf riscv.tar.gz -C /opt/ riscv/
+        run: XZ_OPT="--threads=0 -6e" tar cJf riscv.tar.xz -C /opt/ riscv/
 
       - name: generate prebuilt toolchain name
         id:   toolchain-name-generator
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}
-          path: riscv.tar.gz
+          path: riscv.tar.xz
 
 
   create-release:


### PR DESCRIPTION
To reduce the disk space consumption and upload/download times, let's switch to a better archrive compression algorithm. XZ should be popular enough to not cause many complaints about this.