### PR TITLE
Update .gitmodules to reflect LLVM bump to 18.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,7 +39,7 @@
 [submodule "llvm"]
 	path = llvm
 	url = https://github.com/llvm/llvm-project.git
-	branch = release/17.x
+	branch = release/18.x
 [submodule "uclibc-ng"]
 	path = uclibc-ng
 	url = https://git.uclibc-ng.org/git/uclibc-ng.git


### PR DESCRIPTION
Fixes #1611 
The LLVM submodule was updated to 18.1 in commit 97fce6f and now points to https://github.com/llvm/llvm-project/tree/3b5b5c1ec4a3095ab096dd780e84d7ab81f3d7ff. Make .gitmodules point to that branch as well.