### PR TITLE
Add requirement `python3-tomli` 

### DIFF
--- a/.github/setup-apt.sh
+++ b/.github/setup-apt.sh
@@ -3,7 +3,7 @@
 # install OS prerequisites
 dpkg --add-architecture i386
 apt update
-apt install -y autoconf automake autotools-dev curl python3 python3-pip libmpc-dev libmpfr-dev \
+apt install -y autoconf automake autotools-dev curl python3 python3-pip python3-tomli libmpc-dev libmpfr-dev \
             libgmp-dev gawk build-essential bison flex texinfo gperf libtool \
             patchutils bc zlib1g-dev libexpat-dev git ninja-build cmake libglib2.0-dev expect \
             device-tree-compiler python3-pyelftools libslirp-dev

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Several standard packages are needed to build the toolchain.
 
 On Ubuntu, executing the following command should suffice:
 
-    $ sudo apt-get install autoconf automake autotools-dev curl python3 python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev
+    $ sudo apt-get install autoconf automake autotools-dev curl python3 python3-pip python3-tomli libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev
 
 On Fedora/CentOS/RHEL OS, executing the following command should suffice:
 


### PR DESCRIPTION
python3-tomli required for `build-sim SIM=qemu` in Ubuntu 22.04, I did not try other operating systems. fix https://github.com/riscv-collab/riscv-gnu-toolchain/issues/1615