### PR TITLE
improve cleanup-rootfs.sh

### DIFF
--- a/.github/cleanup-rootfs.sh
+++ b/.github/cleanup-rootfs.sh
@@ -4,7 +4,7 @@
 # while the process moves forward (for apt we'll need to wait for it to finish
 # before we install dependencies later on, but it'll only give us a 1-3GBs so
 # we can skip it.
-WAIT=0 # Set to 1 if you want to wait for the cleanup to finish before proceeding.
+WAIT=1 # Set to 1 if you want to wait for the cleanup to finish before proceeding.
 
 PACKAGES=(
 	"firefox"

--- a/.github/cleanup-rootfs.sh
+++ b/.github/cleanup-rootfs.sh
@@ -4,10 +4,7 @@
 # while the process moves forward (for apt we'll need to wait for it to finish
 # before we install dependencies later on, but it'll only give us a 1-3GBs so
 # we can skip it.
-WAIT=0
-RM=1
-APT=0
-DOCKER=1
+WAIT=0 # Set to 1 if you want to wait for the cleanup to finish before proceeding.
 
 PACKAGES=(
 	"firefox"
@@ -38,32 +35,26 @@ PATHS=(
 
 function cleanup_packages()
 {
-	if [[ ${APT} == 1 ]]; then
-		apt-get purge -y "${PACKAGES[@]}"
-		apt-get autoremove --purge -y
-		apt-get clean
-	fi
+	apt-get purge -y "${PACKAGES[@]}"
+	apt-get autoremove --purge -y
+	apt-get clean
 }
 
 function cleanup_paths()
 {
-	if [[ ${RM} == 1 ]]; then
-		for i in "${PATHS[@]}"; do
-			rm -rf "${i}" &
-		done
-		if [[ ${WAIT} == 1 ]]; then
-			wait
-		fi
+	for i in "${PATHS[@]}"; do
+		rm -rf "${i}" &
+	done
+	if [[ ${WAIT} == 1 ]]; then
+		wait
 	fi
 }
 
 function cleanup_docker()
 {
-	if [[ ${DOCKER} == 1 ]]; then
-		docker image prune --all --force &
-		if [[ ${WAIT} == 1 ]]; then
-			wait
-		fi
+	docker image prune --all --force &
+	if [[ ${WAIT} == 1 ]]; then
+		wait
 	fi
 }
 

--- a/.github/cleanup-rootfs.sh
+++ b/.github/cleanup-rootfs.sh
@@ -7,7 +7,7 @@
 WAIT=0
 RM=1
 APT=0
-DOCKER=0
+DOCKER=1
 
 PACKAGES=(
 	"firefox"


### PR DESCRIPTION
Running `docker image prune --all --force` can save `2.5GB`.

```
Total reclaimed space: 2.454GB
```

I am sending this as enabled to test with workflows. We can make it disabled by default like apt packages.

Or we can enable all, `RM`,`APT`,`DOCKER` and we can `WAIT`. 
it lasts just `25s`.
https://github.com/karaketir16/test-workflows/actions/runs/12079969301/job/33686630344#step:3:1