### PR TITLE
Adjusts default multilib combinations.

### DIFF
--- a/configure
+++ b/configure
@@ -4148,7 +4148,7 @@ fi
 
 if test "x$enable_multilib" != xno
 then :
-  glibc_multilib_names="rv32imac-ilp32 rv32imafdc-ilp32d rv32gc-ilp32d rv64imac-lp64 rv64imafdc-lp64d rv64gc-lp64d rv64gcv-lp64d"
+  glibc_multilib_names="rv32imac-ilp32 rv32gc-ilp32d rv64imac-lp64 rv64gc-lp64d rv64gcv-lp64d"
 
 else $as_nop
   glibc_multilib_names="$with_arch-$with_abi"
@@ -4157,7 +4157,7 @@ fi
 
 if test "x$enable_multilib" != xno
 then :
-  newlib_multilib_names="rv32i-ilp32 rv32iac-ilp32 rv32im-ilp32 rv32imac-ilp32 rv32imafc-ilp32f rv64imac-lp64 rv64imafdc-lp64d rv64gc-lp64d"
+  newlib_multilib_names="rv32i-ilp32 rv32iac-ilp32 rv32im-ilp32 rv32imac-ilp32 rv32imafc-ilp32f rv64imac-lp64 rv64gc-lp64d"
 
 else $as_nop
   newlib_multilib_names="$with_arch-$with_abi"
@@ -4166,7 +4166,7 @@ fi
 
 if test "x$enable_multilib" != xno
 then :
-  musl_multilib_names="rv32imac-ilp32 rv32imafdc-ilp32d rv32gc-ilp32d rv64imac-lp64 rv64imafdc-lp64d rv64gc-lp64d"
+  musl_multilib_names="rv32imac-ilp32 rv32gc-ilp32d rv64imac-lp64 rv64gc-lp64d"
 
 else $as_nop
   musl_multilib_names="$with_arch-$with_abi"

--- a/configure
+++ b/configure
@@ -4148,7 +4148,7 @@ fi
 
 if test "x$enable_multilib" != xno
 then :
-  glibc_multilib_names="rv32imac-ilp32 rv32imafdc-ilp32d rv64imac-lp64 rv64imafdc-lp64d"
+  glibc_multilib_names="rv32imac-ilp32 rv32imafdc-ilp32d rv32gc-ilp32d rv64imac-lp64 rv64imafdc-lp64d rv64gc-lp64d rv64gcv-lp64d"
 
 else $as_nop
   glibc_multilib_names="$with_arch-$with_abi"
@@ -4157,7 +4157,7 @@ fi
 
 if test "x$enable_multilib" != xno
 then :
-  newlib_multilib_names="rv32i-ilp32 rv32iac-ilp32 rv32im-ilp32 rv32imac-ilp32 rv32imafc-ilp32f rv64imac-lp64 rv64imafdc-lp64d"
+  newlib_multilib_names="rv32i-ilp32 rv32iac-ilp32 rv32im-ilp32 rv32imac-ilp32 rv32imafc-ilp32f rv64imac-lp64 rv64imafdc-lp64d rv64gc-lp64d"
 
 else $as_nop
   newlib_multilib_names="$with_arch-$with_abi"
@@ -4166,7 +4166,7 @@ fi
 
 if test "x$enable_multilib" != xno
 then :
-  musl_multilib_names="rv32imac-ilp32 rv32imafdc-ilp32d rv64imac-lp64 rv64imafdc-lp64d"
+  musl_multilib_names="rv32imac-ilp32 rv32imafdc-ilp32d rv32gc-ilp32d rv64imac-lp64 rv64imafdc-lp64d rv64gc-lp64d"
 
 else $as_nop
   musl_multilib_names="$with_arch-$with_abi"

--- a/configure.ac
+++ b/configure.ac
@@ -173,15 +173,15 @@ AS_IF([test "x$enable_multilib" != xno || test "x$with_multilib_generator" != xn
 	[AC_SUBST(multilib_flags,--disable-multilib)])
 
 AS_IF([test "x$enable_multilib" != xno],
-        [AC_SUBST(glibc_multilib_names,"rv32imac-ilp32 rv32imafdc-ilp32d rv64imac-lp64 rv64imafdc-lp64d")],
+        [AC_SUBST(glibc_multilib_names,"rv32imac-ilp32 rv32imafdc-ilp32d rv32gc-ilp32d rv64imac-lp64 rv64imafdc-lp64d rv64gc-lp64d rv64gcv-lp64d")],
         [AC_SUBST(glibc_multilib_names,"$with_arch-$with_abi")])
 
 AS_IF([test "x$enable_multilib" != xno],
-        [AC_SUBST(newlib_multilib_names,"rv32i-ilp32 rv32iac-ilp32 rv32im-ilp32 rv32imac-ilp32 rv32imafc-ilp32f rv64imac-lp64 rv64imafdc-lp64d")],
+        [AC_SUBST(newlib_multilib_names,"rv32i-ilp32 rv32iac-ilp32 rv32im-ilp32 rv32imac-ilp32 rv32imafc-ilp32f rv64imac-lp64 rv64imafdc-lp64d rv64gc-lp64d")],
         [AC_SUBST(newlib_multilib_names,"$with_arch-$with_abi")])
 
 AS_IF([test "x$enable_multilib" != xno],
-        [AC_SUBST(musl_multilib_names,"rv32imac-ilp32 rv32imafdc-ilp32d rv64imac-lp64 rv64imafdc-lp64d")],
+        [AC_SUBST(musl_multilib_names,"rv32imac-ilp32 rv32imafdc-ilp32d rv32gc-ilp32d rv64imac-lp64 rv64imafdc-lp64d rv64gc-lp64d")],
         [AC_SUBST(musl_multilib_names,"$with_arch-$with_abi")])
 
 AC_ARG_ENABLE(gcc-checking,

--- a/configure.ac
+++ b/configure.ac
@@ -173,15 +173,15 @@ AS_IF([test "x$enable_multilib" != xno || test "x$with_multilib_generator" != xn
 	[AC_SUBST(multilib_flags,--disable-multilib)])
 
 AS_IF([test "x$enable_multilib" != xno],
-        [AC_SUBST(glibc_multilib_names,"rv32imac-ilp32 rv32imafdc-ilp32d rv32gc-ilp32d rv64imac-lp64 rv64imafdc-lp64d rv64gc-lp64d rv64gcv-lp64d")],
+        [AC_SUBST(glibc_multilib_names,"rv32imac-ilp32 rv32gc-ilp32d rv64imac-lp64 rv64gc-lp64d rv64gcv-lp64d")],
         [AC_SUBST(glibc_multilib_names,"$with_arch-$with_abi")])
 
 AS_IF([test "x$enable_multilib" != xno],
-        [AC_SUBST(newlib_multilib_names,"rv32i-ilp32 rv32iac-ilp32 rv32im-ilp32 rv32imac-ilp32 rv32imafc-ilp32f rv64imac-lp64 rv64imafdc-lp64d rv64gc-lp64d")],
+        [AC_SUBST(newlib_multilib_names,"rv32i-ilp32 rv32iac-ilp32 rv32im-ilp32 rv32imac-ilp32 rv32imafc-ilp32f rv64imac-lp64 rv64gc-lp64d")],
         [AC_SUBST(newlib_multilib_names,"$with_arch-$with_abi")])
 
 AS_IF([test "x$enable_multilib" != xno],
-        [AC_SUBST(musl_multilib_names,"rv32imac-ilp32 rv32imafdc-ilp32d rv32gc-ilp32d rv64imac-lp64 rv64imafdc-lp64d rv64gc-lp64d")],
+        [AC_SUBST(musl_multilib_names,"rv32imac-ilp32 rv32gc-ilp32d rv64imac-lp64 rv64gc-lp64d")],
         [AC_SUBST(musl_multilib_names,"$with_arch-$with_abi")])
 
 AC_ARG_ENABLE(gcc-checking,


### PR DESCRIPTION
Update the default multilib configurations to include `rv32gc` and `rv64gc`, adapting to the new CSR (Control and Status Registers) and fence extensions requirements. Additionally, add `rv64gcv-lp64d` as a glibc multilib option, aligning with GCC 14.2’s support for RVV (RISC-V Vector) features.

The updates to the `configure` file are automatically handled by `autoconf`.