### PR TITLE
Don't do shallow clones if upstream does not support this

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,9 @@
 	path = binutils
 	url = https://sourceware.org/git/binutils-gdb.git
 	branch = binutils-2_43-branch
-	shallow = true
+	# No shallow cloning because the server does not allow to request
+	# unadvertised objects. However, we need to pin specific git commits.
+	shallow = false
 [submodule "gcc"]
 	path = gcc
 	url = https://gcc.gnu.org/git/gcc.git


### PR DESCRIPTION
Since we changes our cloning strategy to do shallow clones only, all CI builds broke because the upstream servers don't allow us to clone specific commits. The error reads like this:

```
error: Server does not allow request for unadvertised object beb2cdbcda911764b2bed5e57921fe90493260bd
fatal: Fetched in submodule path 'binutils', but it did not contain beb2cdbcda911764b2bed5e57921fe90493260bd. Direct fetching of that commit failed.
```

See also: https://github.com/riscv-collab/riscv-gnu-toolchain/actions/runs/13434377368/job/37533209677?pr=1677

What we could do is to search for our target commit in remote branches, fetch those and then checkout our target commit. See also the following comment for an idea how this could be realized:
  https://github.com/riscv-collab/riscv-gnu-toolchain/issues/1654#issuecomment-2591195261

However, it feels wrong to do add such scripts downstream. We need to find a better solution. But unless we have one, let's just disable shallow clones to unbreak the CI builds.