### PR TITLE
Clean up the guide of dependency installation on ArchLinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ On Fedora/CentOS/RHEL OS, executing the following command should suffice:
     
 On Arch Linux, executing the following command should suffice:
 
-    $ sudo pacman -Syyu autoconf automake curl python3 libmpc mpfr gmp gawk base-devel bison flex texinfo gperf libtool patchutils bc zlib expat libslirp
+    $ sudo pacman -Syu curl python3 libmpc mpfr gmp base-devel texinfo gperf patchutils bc zlib expat libslirp
 
 Also available for Arch users on the AUR: [https://aur.archlinux.org/packages/riscv-gnu-toolchain-bin](https://aur.archlinux.org/packages/riscv-gnu-toolchain-bin)
 


### PR DESCRIPTION
- Avoid -yy flag as it forces synchronization with the package source, causing unnecessary extra traffic.
- Remove dependencies covered by base-devel.

Fixes: 6327954 ("Update README.md")