### PR TITLE
Use github's mirror for sourceware's repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,16 +1,19 @@
+# Some of the external git repos are not upstream servers but upstream clones to
+# avoid "Server does not allow request for unadvertised object" errors (see
+# #1654).
 [submodule "binutils"]
 	path = binutils
-	url = https://sourceware.org/git/binutils-gdb.git
+	url = https://github.com/bminor/binutils-gdb.git
 	branch = binutils-2_44-branch
 	shallow = true
 [submodule "gcc"]
 	path = gcc
-	url = https://gcc.gnu.org/git/gcc.git
+	url = https://github.com/gcc-mirror/gcc.git
 	branch = releases/gcc-14
 	shallow = true
 [submodule "glibc"]
 	path = glibc
-	url = https://sourceware.org/git/glibc.git
+	url = https://github.com/bminor/glibc.git
 	shallow = true
 [submodule "dejagnu"]
 	path = dejagnu
@@ -19,12 +22,12 @@
 	shallow = true
 [submodule "newlib"]
 	path = newlib
-	url = https://sourceware.org/git/newlib-cygwin.git
+	url = https://github.com/bminor/newlib.git
 	branch = master
 	shallow = true
 [submodule "gdb"]
 	path = gdb
-	url = https://sourceware.org/git/binutils-gdb.git
+	url = https://github.com/bminor/binutils-gdb.git
 	branch = gdb-15-branch
 	shallow = true
 [submodule "qemu"]


### PR DESCRIPTION
We use shallow clones to reduce the clone time, however that fesature
seems not well supported on sourceware's server, so we use github's
mirror instead.
