### PR TITLE
Bump GCC from 14.2 to 15.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "gcc"]
 	path = gcc
 	url = https://github.com/gcc-mirror/gcc.git
-	branch = releases/gcc-14
+	branch = releases/gcc-15
 	shallow = true
 [submodule "glibc"]
 	path = glibc


### PR DESCRIPTION
Replacement for this PR to split the bump of GCC and GDB into separate PRs:

- https://github.com/riscv-collab/riscv-gnu-toolchain/pull/1710

Standalone PR for bumping GDB to come.