### PR TITLE
Rename llvm to llvm-project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -49,8 +49,8 @@
 	url = https://github.com/riscv-software-src/riscv-pk.git
 	branch = master
 	shallow = true
-[submodule "llvm"]
-	path = llvm
+[submodule "llvm-project"]
+	path = llvm-project
 	url = https://github.com/llvm/llvm-project.git
 	branch = release/19.x
 	shallow = true

--- a/configure
+++ b/configure
@@ -4569,7 +4569,7 @@ then :
   with_llvm_src=$with_llvm_src
 
 else $as_nop
-  with_llvm_src="\$(srcdir)/llvm"
+  with_llvm_src="\$(srcdir)/llvm-project"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -310,7 +310,7 @@ AX_ARG_WITH_SRC(gdb, gdb)
 AX_ARG_WITH_SRC(qemu, qemu)
 AX_ARG_WITH_SRC(spike, spike)
 AX_ARG_WITH_SRC(pk, pk)
-AX_ARG_WITH_SRC(llvm, llvm)
+AX_ARG_WITH_SRC(llvm, llvm-project)
 AX_ARG_WITH_SRC(dejagnu, dejagnu)
 
 AC_ARG_WITH(linux-headers-src,


### PR DESCRIPTION
To avoid confusion with the subdirectory `llvm` under `llvm-project`