### PR TITLE
setup-apt: Add libzstd-dev to build deps

### DIFF
--- a/.github/setup-apt.sh
+++ b/.github/setup-apt.sh
@@ -6,4 +6,4 @@ apt update
 apt install -y autoconf automake autotools-dev curl python3 python3-pip python3-tomli libmpc-dev libmpfr-dev \
             libgmp-dev gawk build-essential bison flex texinfo gperf libtool \
             patchutils bc zlib1g-dev libexpat-dev git ninja-build cmake libglib2.0-dev expect \
-            device-tree-compiler python3-pyelftools libslirp-dev
+            device-tree-compiler python3-pyelftools libslirp-dev libzstd-dev


### PR DESCRIPTION
GCC and binutils will pick this up and allow compression of the debug sections in elf files using --compress-debug-sections=zstd

The resulting binaries will depend on libzstd1.so, so users must ensure this is installed. It seems to come by default from Ubuntu 20.04 onwards, so that shouldn't be a problem for most.