### PR TITLE
Delete LLVMgold plugin copy

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -20,10 +20,6 @@ ENABLE_DEFAULT_PIE := @enable_default_pie@
 
 SIM ?= @WITH_SIM@
 
-# Shared lib suffix
-IS_DARWIN := $(shell uname -s | grep Darwin)
-SHARED_LIB_SUFFIX := $(if $(IS_DARWIN),dylib,so)
-
 ifeq ($(srcdir)/gcc,$(GCC_SRCDIR))
 # We need a relative source dir for the gcc configure, to make msys2 mingw64
 # builds work.  Mayberelsrcdir is relative if a relative path was used to run
@@ -1204,7 +1200,6 @@ stamps/build-llvm-linux: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BIN
 	    $(MAKE) -C $(notdir $@)/openmp-static install; \
 	fi
 	cp $(notdir $@)/lib/riscv$(XLEN)-unknown-linux-gnu/libc++* $(SYSROOT)/lib
-	cp $(notdir $@)/lib/LLVMgold.$(SHARED_LIB_SUFFIX) $(INSTALL_DIR)/lib
 	cd $(INSTALL_DIR)/bin && ln -s -f clang $(LINUX_TUPLE)-clang && ln -s -f clang++ $(LINUX_TUPLE)-clang++
 	mkdir -p $(dir $@) && touch $@
 
@@ -1225,7 +1220,6 @@ stamps/build-llvm-newlib: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BI
 	    $(LLVM_EXTRA_CONFIGURE_FLAGS)
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
-	cp $(notdir $@)/lib/LLVMgold.$(SHARED_LIB_SUFFIX) $(INSTALL_DIR)/lib
 	cd $(INSTALL_DIR)/bin && ln -s -f clang $(NEWLIB_TUPLE)-clang && \
 	    ln -s -f clang++ $(NEWLIB_TUPLE)-clang++
 	mkdir -p $(dir $@) && touch $@


### PR DESCRIPTION
Under Mingw, LLVMgold plugin has different suffix and location. `make install` can install LLVMgold plugin automatically.