### PR TITLE
Update configure

### DIFF
--- a/configure
+++ b/configure
@@ -1400,7 +1400,7 @@ Optional Packages:
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-arch=rv64gc      Sets the base RISC-V ISA, defaults to rv64gc
   --with-abi=lp64d        Sets the base RISC-V ABI, defaults to lp64d
-  --with-tune=rocket      Set the base RISC-V CPU, defaults to rocket
+  --with-tune=generic     Set the base RISC-V CPU, defaults to generic
   --with-isa-spec=20191213
                           Set the default ISA spec version, default to
                           20191213, available options: 2.2, 20190608, 20191213
@@ -4015,7 +4015,7 @@ if test ${with_tune+y}
 then :
   withval=$with_tune;
 else $as_nop
-  with_tune=rocket
+  with_tune=generic
 
 fi
 


### PR DESCRIPTION
Since the patch "RISC-V: Add generic tune as default" has been commited into the trunk, the configure should also been updated. Here is the link:  https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=20f593018519fec1602dc39c08ba2e674a2d8a1c