### PR TITLE
Update to binutils 2.45

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 [submodule "binutils"]
 	path = binutils
 	url = https://github.com/bminor/binutils-gdb.git
-	branch = binutils-2_44-branch
+	branch = binutils-2_45-branch
 	shallow = true
 [submodule "gcc"]
 	path = gcc


### PR DESCRIPTION
Among other things, this is required for full Zcmp support (already supported by the tagged GCC version).