### PR TITLE
CI/CD: Don't add i386 before installing packages

### DIFF
--- a/.github/setup-apt.sh
+++ b/.github/setup-apt.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # install OS prerequisites
-dpkg --add-architecture i386
 apt update
 apt install -y autoconf automake autotools-dev curl python3 python3-pip python3-tomli libmpc-dev libmpfr-dev \
             libgmp-dev gawk build-essential bison flex texinfo gperf libtool \


### PR DESCRIPTION
We currently add the i386 architecture to apt before installing out build dependencies.  However, there is no use for that and there are a range of drawbacks (we even have ARM builds failing because i386 sources can't be fetched).
Let's drop this.