### PR TITLE
Revert "ci: add arm support"

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:       [ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm]
+        os:       [ubuntu-22.04, ubuntu-24.04]
         mode:     [newlib, linux, musl, uclibc]
         target:   [rv32gc-ilp32d, rv64gc-lp64d]
         compiler: [gcc, llvm]


### PR DESCRIPTION
This reverts commit fdb0813830b6788d1fddfefc9702ea72b463991c.

The reason is that ARM builds exceed their maximum build duration of 1h26min and thus block the nightly releases.