### PR TITLE
CI/CD: nightly-release: Don't fail fast

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -47,6 +47,7 @@ jobs:
     if: needs.activity-check.outputs.stale != 'true'
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:       [ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm]
         mode:     [newlib, linux, musl, uclibc]


### PR DESCRIPTION
The default strategy is for GItHub CI/CD pipelines is to cancel all runners when one runner observes an error. The idea is to keep the workload of the runners low and an error likely leads to a future source code change (making the results of the other runners irrelevant). This is reasonable for testing PRs with unknown expectation.

However, for our nightly release builds, we observe that errors are typically caused by the runners and not by the contents of this repo. Therefore, we address build issues of the nightly releases by re-running all failed builds, which includes those which have been canceled because of the error. Letting all runners complete their build is a better option in this case, as we don't need to re-start builds that would have succeeded. And that's what this patch does.