### PR TITLE
Adding arch and abi in binutils targets

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -383,6 +383,8 @@ stamps/build-binutils-linux: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) $(PREPARATIO
 		--disable-sim \
 		--disable-libdecnumber \
 		--disable-readline \
+		$(WITH_ABI) \
+		$(WITH_ARCH) \
 		$(WITH_ISA_SPEC)
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) $(INSTALL_TARGET)
@@ -556,6 +558,8 @@ stamps/build-binutils-linux-native: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamp
 		--disable-sim \
 		--disable-libdecnumber \
 		--disable-readline \
+		$(WITH_ABI) \
+		$(WITH_ARCH) \
 		$(WITH_ISA_SPEC)
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) $(INSTALL_TARGET)
@@ -614,6 +618,8 @@ stamps/build-binutils-newlib: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) $(PREPARATI
 		--disable-sim \
 		--disable-libdecnumber \
 		--disable-readline \
+		$(WITH_ABI) \
+		$(WITH_ARCH) \
 		$(WITH_ISA_SPEC)
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) $(INSTALL_TARGET)
@@ -807,6 +813,8 @@ stamps/build-binutils-musl: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) $(PREPARATION
 		--disable-sim \
 		--disable-libdecnumber \
 		--disable-readline \
+		$(WITH_ABI) \
+		$(WITH_ARCH) \
 		$(WITH_ISA_SPEC)
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) $(INSTALL_TARGET)
@@ -968,6 +976,8 @@ stamps/build-binutils-uclibc: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) $(PREPARATI
 		--disable-sim \
 		--disable-libdecnumber \
 		--disable-readline \
+		$(WITH_ABI) \
+		$(WITH_ARCH) \
 		$(WITH_ISA_SPEC)
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) $(INSTALL_TARGET)


### PR DESCRIPTION
As we're discussing here: [https://github.com/riscv-collab/riscv-gnu-toolchain/issues/1755](https://github.com/riscv-collab/riscv-gnu-toolchain/issues/1755).
I added the `WITH_ABI` and `WITH_ARCH` targets to all five different binutils targets.

I tested the four cross-compilers targets of them with a simple assembly code (with vector instructions) and looks fine.