### PR TITLE
Build and install LLVM libraries/tools

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1160,7 +1160,7 @@ stamps/build-llvm-linux: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BIN
 	    -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR) \
 	    -DCMAKE_BUILD_TYPE=Release \
 	    -DLLVM_TARGETS_TO_BUILD="RISCV" \
-	    -DLLVM_ENABLE_PROJECTS="clang;lld" \
+	    -DLLVM_ENABLE_PROJECTS="llvm;clang;lld" \
 	    -DLLVM_ENABLE_RUNTIMES="compiler-rt;libcxx;libcxxabi;libunwind" \
 	    -DLLVM_DEFAULT_TARGET_TRIPLE="$(LINUX_TUPLE)" \
 	    -DDEFAULT_SYSROOT="../sysroot" \
@@ -1225,7 +1225,7 @@ stamps/build-llvm-newlib: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BI
 	    -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR) \
 	    -DCMAKE_BUILD_TYPE=Release \
 	    -DLLVM_TARGETS_TO_BUILD="RISCV" \
-	    -DLLVM_ENABLE_PROJECTS="clang;lld" \
+	    -DLLVM_ENABLE_PROJECTS="llvm;clang;lld" \
 	    -DLLVM_DEFAULT_TARGET_TRIPLE="$(NEWLIB_TUPLE)" \
 	    -DLLVM_INSTALL_TOOLCHAIN_ONLY=On \
 	    -DLLVM_BINUTILS_INCDIR=$(BINUTILS_SRCDIR)/include \


### PR DESCRIPTION
We don't build and install `llvm` subproject so LLVM libraries and tools like `llvm-mc` can't be found.