### PR TITLE
Add profile support in '--with-arch' option.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -152,7 +152,13 @@ GCC_WITH_SPECS := @gcc_with_specs@
 
 EXTRA_MULTILIB_TEST := @extra_multilib_test@
 
-XLEN := $(shell echo $(WITH_ARCH) | tr A-Z a-z | sed 's/.*rv\([0-9]*\).*/\1/')
+arch_xlen = $(shell echo $(1) | tr A-Z a-z | sed 's/.*--with-arch=//' | sed -n \
+	-e 's/^rv\([0-9][0-9]*\).*/\1/p' \
+	-e 's/^\(rvi[0-9][0-9]*u\|rva[0-9][0-9]*u\|rvb[0-9][0-9]*u\)\([0-9][0-9]*\)\(_.*\)\{0,1\}$$/\2/p' \
+	-e 's/^\(rva[0-9][0-9]*s\|rvb[0-9][0-9]*s\)\([0-9][0-9]*\)\(_.*\)\{0,1\}$$/\2/p' \
+	| head -n 1)
+
+XLEN := $(call arch_xlen,$(WITH_ARCH))
 ifneq ($(XLEN),32)
 	XLEN := 64
 endif
@@ -536,8 +542,8 @@ else
 	$(eval $@_ARCH := )
 	$(eval $@_ABI := )
 endif
-	$(eval $@_LIBDIRSUFFIX := $(if $($@_ABI),$(shell echo $($@_ARCH) | sed 's/.*rv\([0-9]*\).*/\1/')/$($@_ABI),))
-	$(eval $@_XLEN := $(if $($@_ABI),$(shell echo $($@_ARCH) | sed 's/.*rv\([0-9]*\).*/\1/'),$(XLEN)))
+	$(eval $@_LIBDIRSUFFIX := $(if $($@_ABI),$(call arch_xlen,$($@_ARCH))/$($@_ABI),))
+	$(eval $@_XLEN := $(if $($@_ABI),$(call arch_xlen,$($@_ARCH)),$(XLEN)))
 	$(eval $@_CFLAGS := $(if $($@_ABI),-march=$($@_ARCH) -mabi=$($@_ABI),))
 	$(eval $@_LIBDIROPTS := $(if $@_LIBDIRSUFFIX,--libdir=/usr/lib$($@_LIBDIRSUFFIX) libc_cv_slibdir=/lib$($@_LIBDIRSUFFIX) libc_cv_rtlddir=/lib,))
 	rm -rf $@ $(notdir $@)
@@ -1348,7 +1354,7 @@ stamps/check-dhrystone-newlib-%: \
 		$(wildcard $(srcdir)/test/benchmarks/dhrystone/*)
 	$(eval $@_ARCH := $(word 4,$(subst -, ,$@)))
 	$(eval $@_ABI := $(word 5,$(subst -, ,$@)))
-	$(eval $@_XLEN := $(patsubst rv32%,32,$(patsubst rv64%,64,$($@_ARCH))))
+	$(eval $@_XLEN := $(call arch_xlen,$($@_ARCH)))
 	$(SIM_PREPARE) $(srcdir)/test/benchmarks/dhrystone/check -march=$($@_ARCH) -mabi=$($@_ABI) -cc=riscv$(XLEN)-unknown-elf-gcc -objdump=riscv$(XLEN)-unknown-elf-objdump -sim=riscv$($@_XLEN)-unknown-elf-run -out=$@ $(filter %.c,$^) || true
 
 stamps/check-dhrystone-newlib-nano-%: \
@@ -1357,7 +1363,7 @@ stamps/check-dhrystone-newlib-nano-%: \
 		$(wildcard $(srcdir)/test/benchmarks/dhrystone/*)
 	$(eval $@_ARCH := $(word 5,$(subst -, ,$@)))
 	$(eval $@_ABI := $(word 6,$(subst -, ,$@)))
-	$(eval $@_XLEN := $(patsubst rv32%,32,$(patsubst rv64%,64,$($@_ARCH))))
+	$(eval $@_XLEN := $(call arch_xlen,$($@_ARCH)))
 	$(SIM_PREPARE) $(srcdir)/test/benchmarks/dhrystone/check -march=$($@_ARCH) -mabi=$($@_ABI) -specs=nano.specs -cc=riscv$(XLEN)-unknown-elf-gcc -objdump=riscv$(XLEN)-unknown-elf-objdump -sim=riscv$($@_XLEN)-unknown-elf-run -out=$@ $(filter %.c,$^) || true
 
 .PHONY: check-dhrystone-linux
@@ -1369,7 +1375,7 @@ stamps/check-dhrystone-linux-%: \
 		$(wildcard $(srcdir)/test/benchmarks/dhrystone/*)
 	$(eval $@_ARCH := $(word 4,$(subst -, ,$@)))
 	$(eval $@_ABI := $(word 5,$(subst -, ,$@)))
-	$(eval $@_XLEN := $(patsubst rv32%,32,$(patsubst rv64%,64,$($@_ARCH))))
+	$(eval $@_XLEN := $(call arch_xlen,$($@_ARCH)))
 	$(SIM_PREPARE) $(srcdir)/test/benchmarks/dhrystone/check -march=$($@_ARCH) -mabi=$($@_ABI) -cc=riscv$(XLEN)-unknown-elf-gcc -objdump=riscv$(XLEN)-unknown-elf-objdump -sim=riscv$($@_XLEN)-unknown-elf-run -out=$@ $(filter %.c,$^) || true
 
 stamps/check-binutils-newlib: stamps/build-gcc-newlib-stage2 $(SIM_STAMP) stamps/build-dejagnu

--- a/Makefile.in
+++ b/Makefile.in
@@ -334,10 +334,11 @@ ifeq ($(SIM),spike)
 SIM_PATH:=$(srcdir)/scripts/wrapper/spike:$(srcdir)/scripts
 SIM_PREPARE:=PATH="$(SIM_PATH):$(INSTALL_DIR)/bin:$(PATH)" PK_PATH="$(INSTALL_DIR)/$(NEWLIB_TUPLE)/bin/" ARCH_STR="$(WITH_ARCH)"
 SIM_STAMP:= stamps/build-spike
-ifneq (,$(findstring rv32,$(NEWLIB_MULTILIB_NAMES)))
+SIM_XLENS := $(foreach arch_abi,$(NEWLIB_MULTILIB_NAMES),$(call arch_xlen,$(word 1,$(subst -, ,$(arch_abi)))))
+ifneq (,$(filter 32,$(SIM_XLENS)))
 SIM_STAMP+= stamps/build-pk32
 endif
-ifneq (,$(findstring rv64,$(NEWLIB_MULTILIB_NAMES)))
+ifneq (,$(filter 64,$(SIM_XLENS)))
 SIM_STAMP+= stamps/build-pk64
 endif
 else

--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ Supported ABIs are ilp32 (32-bit soft-float), ilp32d (32-bit hard-float),
 ilp32f (32-bit with single-precision in registers and double in memory, niche
 use only), lp64 lp64f lp64d (same but with 64-bit long and pointers).
 
+### Build with RISC-V Profiles
+
+The top-level `--with-arch` option accepts RISC-V profile names and profile
+strings combined with additional ISA extensions as the default architecture:
+
+    ./configure --prefix=/opt/riscv --enable-linux --with-arch=rva20u64
+    ./configure --prefix=/opt/riscv --enable-linux --with-arch=rva23u64
+    ./configure --prefix=/opt/riscv --enable-linux --with-arch=rva23u64_zacas
+
+If `--with-abi` is omitted, the ABI is inferred from the profile base. For
+example, `rva20u64`, `rva22u64`, `rva23u64`, and `rva23u64_zacas` default to
+`lp64d`.
+
 ### Installation (Newlib/Linux multilib)
 
 To build either cross-compiler with support for both 32-bit and

--- a/configure
+++ b/configure
@@ -34,7 +34,6 @@ esac
 fi
 
 
-
 # Reset variables that may have inherited troublesome values from
 # the environment.
 
@@ -1405,7 +1404,8 @@ Optional Features:
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
-  --with-arch=rv64gc      Sets the base RISC-V ISA, defaults to rv64gc
+  --with-arch=ISA|PROFILE Sets the default RISC-V ISA or profile string,
+                          defaults to rv64gc
   --with-abi=lp64d        Sets the base RISC-V ABI, defaults to lp64d
   --with-tune=generic     Set the base RISC-V CPU, defaults to GCC's default
   --with-isa-spec=20191213
@@ -4052,6 +4052,31 @@ then :
 
 fi
 
+riscv_profile_base=no
+riscv_arch_base=`echo "$with_arch" | sed 's/_.*//'`
+case $riscv_arch_base in #(
+  rvi20u32 | rvi20u64 | rva20u64 | rva22u64 | rva23u64 | rva23s64 | rvb23u64 | rvb23s64) :
+    riscv_profile_base=$riscv_arch_base ;; #(
+  rvi* | rva* | rvb*) :
+    as_fn_error $? "unsupported RISC-V profile '$riscv_arch_base' in --with-arch=$with_arch" "$LINENO" 5 ;; #(
+  *) :
+     ;;
+esac
+
+if test "x$with_abi" = xdefault
+then :
+  case $riscv_profile_base in #(
+  rvi20u32) :
+    with_abi=ilp32 ;; #(
+  rvi20u64) :
+    with_abi=lp64 ;; #(
+  rva20u64 | rva22u64 | rva23u64 | rva23s64 | rvb23u64 | rvb23s64) :
+    with_abi=lp64d ;; #(
+  *) :
+     ;;
+esac
+
+fi
 
 if test "x$with_abi" = xdefault
 then :

--- a/configure
+++ b/configure
@@ -4101,6 +4101,32 @@ then :
 esac
 fi
 
+case $riscv_profile_base in #(
+  rvi20u32) :
+    case $with_abi in #(
+  ilp32) :
+     ;; #(
+  *) :
+    as_fn_error $? "ABI '$with_abi' is incompatible with RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected ilp32" "$LINENO" 5 ;;
+esac ;; #(
+  rvi20u64) :
+    case $with_abi in #(
+  lp64) :
+     ;; #(
+  *) :
+    as_fn_error $? "ABI '$with_abi' is incompatible with RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected lp64" "$LINENO" 5 ;;
+esac ;; #(
+  rva20u64 | rva22u64 | rva23u64 | rva23s64 | rvb23u64 | rvb23s64) :
+    case $with_abi in #(
+  lp64 | lp64f | lp64d) :
+     ;; #(
+  *) :
+    as_fn_error $? "ABI '$with_abi' is incompatible with RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected lp64, lp64f, or lp64d" "$LINENO" 5 ;;
+esac ;; #(
+  *) :
+     ;;
+esac
+
 WITH_ARCH=--with-arch=$with_arch
 
 WITH_ABI=--with-abi=$with_abi

--- a/configure
+++ b/configure
@@ -4055,10 +4055,8 @@ fi
 riscv_profile_base=no
 riscv_arch_base=`echo "$with_arch" | sed 's/_.*//'`
 case $riscv_arch_base in #(
-  rvi20u32 | rvi20u64 | rva20u64 | rva22u64 | rva23u64 | rva23s64 | rvb23u64 | rvb23s64) :
-    riscv_profile_base=$riscv_arch_base ;; #(
   rvi* | rva* | rvb*) :
-    as_fn_error $? "unsupported RISC-V profile '$riscv_arch_base' in --with-arch=$with_arch" "$LINENO" 5 ;; #(
+    riscv_profile_base=$riscv_arch_base ;; #(
   *) :
      ;;
 esac
@@ -4066,11 +4064,11 @@ esac
 if test "x$with_abi" = xdefault
 then :
   case $riscv_profile_base in #(
-  rvi20u32) :
+  rvi*u32) :
     with_abi=ilp32 ;; #(
-  rvi20u64) :
+  rvi*u64) :
     with_abi=lp64 ;; #(
-  rva20u64 | rva22u64 | rva23u64 | rva23s64 | rvb23u64 | rvb23s64) :
+  rva*u64 | rva*s64 | rvb*u64 | rvb*s64) :
     with_abi=lp64d ;; #(
   *) :
      ;;
@@ -4102,21 +4100,21 @@ esac
 fi
 
 case $riscv_profile_base in #(
-  rvi20u32) :
+  rvi*u32) :
     case $with_abi in #(
   ilp32) :
      ;; #(
   *) :
     as_fn_error $? "ABI '$with_abi' is incompatible with RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected ilp32" "$LINENO" 5 ;;
 esac ;; #(
-  rvi20u64) :
+  rvi*u64) :
     case $with_abi in #(
   lp64) :
      ;; #(
   *) :
     as_fn_error $? "ABI '$with_abi' is incompatible with RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected lp64" "$LINENO" 5 ;;
 esac ;; #(
-  rva20u64 | rva22u64 | rva23u64 | rva23s64 | rvb23u64 | rvb23s64) :
+  rva*u64 | rva*s64 | rvb*u64 | rvb*s64) :
     case $with_abi in #(
   lp64 | lp64f | lp64d) :
      ;; #(

--- a/configure
+++ b/configure
@@ -4102,24 +4102,17 @@ fi
 case $riscv_profile_base in #(
   rvi*u32) :
     case $with_abi in #(
-  ilp32) :
+  ilp32 | ilp32f | ilp32d) :
      ;; #(
   *) :
-    as_fn_error $? "ABI '$with_abi' is incompatible with RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected ilp32" "$LINENO" 5 ;;
+    as_fn_error $? "ABI '$with_abi' is incompatible with 32-bit RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected ilp32, ilp32f, or ilp32d" "$LINENO" 5 ;;
 esac ;; #(
-  rvi*u64) :
-    case $with_abi in #(
-  lp64) :
-     ;; #(
-  *) :
-    as_fn_error $? "ABI '$with_abi' is incompatible with RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected lp64" "$LINENO" 5 ;;
-esac ;; #(
-  rva*u64 | rva*s64 | rvb*u64 | rvb*s64) :
+  rvi*u64 | rva*u64 | rva*s64 | rvb*u64 | rvb*s64) :
     case $with_abi in #(
   lp64 | lp64f | lp64d) :
      ;; #(
   *) :
-    as_fn_error $? "ABI '$with_abi' is incompatible with RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected lp64, lp64f, or lp64d" "$LINENO" 5 ;;
+    as_fn_error $? "ABI '$with_abi' is incompatible with 64-bit RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected lp64, lp64f, or lp64d" "$LINENO" 5 ;;
 esac ;; #(
   *) :
      ;;

--- a/configure.ac
+++ b/configure.ac
@@ -112,16 +112,14 @@ AC_ARG_WITH(languages,
 riscv_profile_base=no
 riscv_arch_base=`echo "$with_arch" | sed 's/_.*//'`
 AS_CASE([$riscv_arch_base],
-	[rvi20u32 | rvi20u64 | rva20u64 | rva22u64 | rva23u64 | rva23s64 | rvb23u64 | rvb23s64],
-		[riscv_profile_base=$riscv_arch_base],
 	[rvi* | rva* | rvb*],
-		[AC_MSG_ERROR([unsupported RISC-V profile '$riscv_arch_base' in --with-arch=$with_arch])])
+		[riscv_profile_base=$riscv_arch_base])
 
 AS_IF([test "x$with_abi" = xdefault],
 	[AS_CASE([$riscv_profile_base],
-		[rvi20u32], [with_abi=ilp32],
-		[rvi20u64], [with_abi=lp64],
-		[rva20u64 | rva22u64 | rva23u64 | rva23s64 | rvb23u64 | rvb23s64], [with_abi=lp64d])
+		[rvi*u32], [with_abi=ilp32],
+		[rvi*u64], [with_abi=lp64],
+		[rva*u64 | rva*s64 | rvb*u64 | rvb*s64], [with_abi=lp64d])
 	])
 
 AS_IF([test "x$with_abi" = xdefault],
@@ -137,15 +135,15 @@ AS_IF([test "x$with_abi" = xdefault],
 	)])
 
 AS_CASE([$riscv_profile_base],
-	[rvi20u32],
+	[rvi*u32],
 		[AS_CASE([$with_abi],
 			[ilp32], [],
 			[AC_MSG_ERROR([ABI '$with_abi' is incompatible with RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected ilp32])])],
-	[rvi20u64],
+	[rvi*u64],
 		[AS_CASE([$with_abi],
 			[lp64], [],
 			[AC_MSG_ERROR([ABI '$with_abi' is incompatible with RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected lp64])])],
-	[rva20u64 | rva22u64 | rva23u64 | rva23s64 | rvb23u64 | rvb23s64],
+	[rva*u64 | rva*s64 | rvb*u64 | rvb*s64],
 		[AS_CASE([$with_abi],
 			[lp64 | lp64f | lp64d], [],
 			[AC_MSG_ERROR([ABI '$with_abi' is incompatible with RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected lp64, lp64f, or lp64d])])])

--- a/configure.ac
+++ b/configure.ac
@@ -136,6 +136,20 @@ AS_IF([test "x$with_abi" = xdefault],
 		[AC_MSG_ERROR([Unknown arch])]
 	)])
 
+AS_CASE([$riscv_profile_base],
+	[rvi20u32],
+		[AS_CASE([$with_abi],
+			[ilp32], [],
+			[AC_MSG_ERROR([ABI '$with_abi' is incompatible with RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected ilp32])])],
+	[rvi20u64],
+		[AS_CASE([$with_abi],
+			[lp64], [],
+			[AC_MSG_ERROR([ABI '$with_abi' is incompatible with RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected lp64])])],
+	[rva20u64 | rva22u64 | rva23u64 | rva23s64 | rvb23u64 | rvb23s64],
+		[AS_CASE([$with_abi],
+			[lp64 | lp64f | lp64d], [],
+			[AC_MSG_ERROR([ABI '$with_abi' is incompatible with RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected lp64, lp64f, or lp64d])])])
+
 AC_SUBST(WITH_ARCH, --with-arch=$with_arch)
 AC_SUBST(WITH_ABI, --with-abi=$with_abi)
 AC_SUBST(WITH_ISA_SPEC, --with-isa-spec=$with_isa_spec)

--- a/configure.ac
+++ b/configure.ac
@@ -65,8 +65,8 @@ AS_IF([test "x$enable_default_pie" = xyes],
 	[AC_SUBST(enable_default_pie, "--disable-default-pie")])
 
 AC_ARG_WITH(arch,
-	[AS_HELP_STRING([--with-arch=rv64gc],
-		[Sets the base RISC-V ISA, defaults to rv64gc])],
+	[AS_HELP_STRING([--with-arch=ISA|PROFILE],
+		[Sets the default RISC-V ISA or profile string, defaults to rv64gc])],
 	[],
 	[with_arch=rv64gc]
 	)
@@ -108,6 +108,21 @@ AC_ARG_WITH(languages,
 		[Sets the enabled languages for GNU toolchain, defaults to c,c++,fortran for Linux/native and Linux/glibc or c,c++ for Bare-metal, Linux/musl and Linux/uClibc])],
 	[]
 	) 
+
+riscv_profile_base=no
+riscv_arch_base=`echo "$with_arch" | sed 's/_.*//'`
+AS_CASE([$riscv_arch_base],
+	[rvi20u32 | rvi20u64 | rva20u64 | rva22u64 | rva23u64 | rva23s64 | rvb23u64 | rvb23s64],
+		[riscv_profile_base=$riscv_arch_base],
+	[rvi* | rva* | rvb*],
+		[AC_MSG_ERROR([unsupported RISC-V profile '$riscv_arch_base' in --with-arch=$with_arch])])
+
+AS_IF([test "x$with_abi" = xdefault],
+	[AS_CASE([$riscv_profile_base],
+		[rvi20u32], [with_abi=ilp32],
+		[rvi20u64], [with_abi=lp64],
+		[rva20u64 | rva22u64 | rva23u64 | rva23s64 | rvb23u64 | rvb23s64], [with_abi=lp64d])
+	])
 
 AS_IF([test "x$with_abi" = xdefault],
 	[AS_CASE([$with_arch],

--- a/configure.ac
+++ b/configure.ac
@@ -137,16 +137,12 @@ AS_IF([test "x$with_abi" = xdefault],
 AS_CASE([$riscv_profile_base],
 	[rvi*u32],
 		[AS_CASE([$with_abi],
-			[ilp32], [],
-			[AC_MSG_ERROR([ABI '$with_abi' is incompatible with RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected ilp32])])],
-	[rvi*u64],
-		[AS_CASE([$with_abi],
-			[lp64], [],
-			[AC_MSG_ERROR([ABI '$with_abi' is incompatible with RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected lp64])])],
-	[rva*u64 | rva*s64 | rvb*u64 | rvb*s64],
+			[ilp32 | ilp32f | ilp32d], [],
+			[AC_MSG_ERROR([ABI '$with_abi' is incompatible with 32-bit RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected ilp32, ilp32f, or ilp32d])])],
+	[rvi*u64 | rva*u64 | rva*s64 | rvb*u64 | rvb*s64],
 		[AS_CASE([$with_abi],
 			[lp64 | lp64f | lp64d], [],
-			[AC_MSG_ERROR([ABI '$with_abi' is incompatible with RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected lp64, lp64f, or lp64d])])])
+			[AC_MSG_ERROR([ABI '$with_abi' is incompatible with 64-bit RISC-V profile '$riscv_profile_base' in --with-arch=$with_arch; expected lp64, lp64f, or lp64d])])])
 
 AC_SUBST(WITH_ARCH, --with-arch=$with_arch)
 AC_SUBST(WITH_ABI, --with-abi=$with_abi)

--- a/scripts/testsuite-filter
+++ b/scripts/testsuite-filter
@@ -12,8 +12,11 @@ debug = False
 
 class Arch:
     def __init__(self, arch):
+        arch = self._normalize_profile_arch(arch)
         arch = re.sub("^rv(32|64|128)g", 'rv\\1imafd', arch)
         m = re.match('rv(32|64|128)', arch)
+        if m is None:
+            raise ValueError("Unsupported RISC-V architecture: %s" % arch)
         self.base_arch = m.group(0)
         self.ext = []
         i = len(self.base_arch)
@@ -31,6 +34,15 @@ class Arch:
             else:
                 self.ext.append(ext)
                 i += 1
+
+    def _normalize_profile_arch(self, arch):
+        m = re.match(r'(rvi[0-9]+u32|(?:rvi|rva|rvb)[0-9]+u64|'
+                     r'(?:rva|rvb)[0-9]+s64)(?:_|$)', arch)
+        if m is None:
+            return arch
+
+        base_arch = 'rv32' if m.group(1).endswith('u32') else 'rv64'
+        return base_arch + arch[m.end():]
 
 
 def usage():

--- a/test/benchmarks/dhrystone/check
+++ b/test/benchmarks/dhrystone/check
@@ -46,6 +46,21 @@ end_cycle="$(grep -n 00$end_pc $tempdir/log | cut -d: -f1)"
 cycles="$(echo $((end_cycle - begin_cycle)) | rev | cut -c4- | rev)"
 
 unset max_cycles
+profile_base="${march%%_*}"
+case "$profile_base" in
+rvi*u32)
+  case "$mabi" in
+  ilp32)              max_cycles=377;;
+  ilp32f | ilp32d)   max_cycles=304;;
+  esac;;
+rvi*u64 | rva*u64 | rva*s64 | rvb*u64 | rvb*s64)
+  case "$mabi" in
+  lp64 | lp64f | lp64d) max_cycles=287;;
+  esac;;
+esac
+
+if [[ -z "${max_cycles:-}" ]]
+then
 case "$march-$mabi" in
 rv32i-ilp32)     max_cycles=377;;
 rv32iac-ilp32)   max_cycles=377;;
@@ -57,6 +72,7 @@ rv64imafdc-lp64) max_cycles=287;;
 rv64imafdc-lp64d)max_cycles=287;;
 *) echo "ERROR: Unknown ISA-ABI pair: $march-$mabi" >$out; exit 0;;
 esac
+fi
 
 if test $cycles -le $max_cycles
 then


### PR DESCRIPTION
Extend the top-level --with-arch handling so RISC-V profile strings
combined with additional ISA extensions are accepted as default
architecture strings.

This allows configurations such as:

  --with-arch=rva23u64
  --with-arch=rvi20u64_zbc
  --with-arch=rvi20u32_zba_zbb

ABI and XLEN inference are based on the profile base, while the original
--with-arch string is preserved and passed through to the toolchain
components.