### PR TITLE
CI/CD: Add medany and large code model to multilib 

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -46,6 +46,10 @@ on:
         description: "Build simulator and include in the toolchain"
         type: boolean
         default: false
+      baremetal-multilib:
+        description: "Whether to build multi-lib for baremetal (newlib) mode"
+        type: string
+        default: "rv32i-ilp32--c;rv32im-ilp32--c;rv32iac-ilp32--;rv32imac-ilp32--;rv32imafc-ilp32f-rv32imafdc-;rv64imac-lp64--;rv64imafdc-lp64d--;--cmodel;medany,large"
 
 env:
   submodule_paths: |
@@ -147,6 +151,8 @@ jobs:
           - ${{ inputs.report }}
         build-sim:
           - ${{ inputs.build-sim }}
+        baremetal-multilib:
+          - ${{ inputs.baremetal-multilib }}
 
         exclude:
           - mode: uclibc
@@ -216,6 +222,9 @@ jobs:
           TARGET_TUPLE=($(echo ${{ matrix.target }} | tr "-" "\n"))
           BUILD_TOOLCHAIN="./configure --prefix=/mnt/riscv --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]}"
           ARGS=""
+          if [ "${{ matrix.mode }}" == "newlib" ] && [ -n "${{ matrix.baremetal-multilib }}" ]; then # build toolchain with newlib
+            ARGS="$ARGS --with-multilib-generator=\"${{ matrix.baremetal-multilib }}\""
+          fi
           if [ "${{ matrix.compiler }}" == "llvm" ]; then # build toolchain with llvm
             ARGS="$ARGS --enable-llvm"
           fi

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -227,7 +227,11 @@ jobs:
           MATRIX_CMODEL: ${{ matrix.cmodel }}
           MATRIX_LANGUAGES: ${{ matrix.languages }}
           MATRIX_STRIP: ${{ matrix.strip }}
+          # Halve LLVM link parallelism (default 4) to cut peak memory
+          LLVM_PARALLEL_LINK_JOBS: 2
         run: |
+          # Halve LLVM compile parallelism
+          export LLVM_PARALLEL_JOBS=$(( $(nproc) / 2 > 0 ? $(nproc) / 2 : 1 ))
           TARGET_TUPLE=($(echo "$MATRIX_TARGET" | tr "-" "\n"))
           ARGS=(--prefix=/mnt/riscv --with-arch="${TARGET_TUPLE[0]}" --with-abi="${TARGET_TUPLE[1]}")
           if [ "$MATRIX_MODE" == "newlib" ] && [ "$MATRIX_COMPILER" != "llvm" ] && [ -n "$MATRIX_BAREMETAL_MULTILIB" ]; then

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -222,7 +222,7 @@ jobs:
           TARGET_TUPLE=($(echo ${{ matrix.target }} | tr "-" "\n"))
           BUILD_TOOLCHAIN="./configure --prefix=/mnt/riscv --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]}"
           ARGS=""
-          if [ "${{ matrix.mode }}" == "newlib" ] && [ -n "${{ matrix.baremetal-multilib }}" ]; then # build toolchain with newlib
+          if [ "${{ matrix.mode }}" == "newlib" ] && [ "${{ matrix.compiler }}" != "llvm" ] && [ -n "${{ matrix.baremetal-multilib }}" ]; then
             ARGS="$ARGS --with-multilib-generator=\"${{ matrix.baremetal-multilib }}\""
           fi
           if [ "${{ matrix.compiler }}" == "llvm" ]; then # build toolchain with llvm

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -218,32 +218,40 @@ jobs:
           ccache -s
 
       - name: build toolchain
+        env:
+          MATRIX_MODE: ${{ matrix.mode }}
+          MATRIX_COMPILER: ${{ matrix.compiler }}
+          MATRIX_TARGET: ${{ matrix.target }}
+          MATRIX_BAREMETAL_MULTILIB: ${{ matrix.baremetal-multilib }}
+          MATRIX_SIM: ${{ matrix.sim }}
+          MATRIX_CMODEL: ${{ matrix.cmodel }}
+          MATRIX_LANGUAGES: ${{ matrix.languages }}
+          MATRIX_STRIP: ${{ matrix.strip }}
         run: |
-          TARGET_TUPLE=($(echo ${{ matrix.target }} | tr "-" "\n"))
-          BUILD_TOOLCHAIN="./configure --prefix=/mnt/riscv --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]}"
-          ARGS=""
-          if [ "${{ matrix.mode }}" == "newlib" ] && [ "${{ matrix.compiler }}" != "llvm" ] && [ -n "${{ matrix.baremetal-multilib }}" ]; then
-            ARGS="$ARGS --with-multilib-generator=\"${{ matrix.baremetal-multilib }}\""
+          TARGET_TUPLE=($(echo "$MATRIX_TARGET" | tr "-" "\n"))
+          ARGS=(--prefix=/mnt/riscv --with-arch="${TARGET_TUPLE[0]}" --with-abi="${TARGET_TUPLE[1]}")
+          if [ "$MATRIX_MODE" == "newlib" ] && [ "$MATRIX_COMPILER" != "llvm" ] && [ -n "$MATRIX_BAREMETAL_MULTILIB" ]; then
+            ARGS+=(--with-multilib-generator="$MATRIX_BAREMETAL_MULTILIB")
           fi
-          if [ "${{ matrix.compiler }}" == "llvm" ]; then # build toolchain with llvm
-            ARGS="$ARGS --enable-llvm"
+          if [ "$MATRIX_COMPILER" == "llvm" ]; then # build toolchain with llvm
+            ARGS+=(--enable-llvm)
           fi
-          if [ -n "${{ matrix.sim }}" ]; then
-            ARGS="$ARGS --with-sim=${{ matrix.sim }}"
+          if [ -n "$MATRIX_SIM" ]; then
+            ARGS+=(--with-sim="$MATRIX_SIM")
           fi
-          if [ -n "${{ matrix.cmodel }}" ]; then
-            ARGS="$ARGS --with-cmodel=${{ matrix.cmodel }}"
+          if [ -n "$MATRIX_CMODEL" ]; then
+            ARGS+=(--with-cmodel="$MATRIX_CMODEL")
           fi
-          if [ -n "${{ matrix.languages }}" ]; then
-            ARGS="$ARGS --with-languages=${{ matrix.languages }}"
+          if [ -n "$MATRIX_LANGUAGES" ]; then
+            ARGS+=(--with-languages="$MATRIX_LANGUAGES")
           fi
-          if [ "${{ matrix.strip }}" = "true" ]; then
-            ARGS="$ARGS --enable-strip"
+          if [ "$MATRIX_STRIP" = "true" ]; then
+            ARGS+=(--enable-strip)
           fi
-          $BUILD_TOOLCHAIN $ARGS
+          ./configure "${ARGS[@]}"
           sudo mkdir /mnt/riscv
           sudo chown runner:runner /mnt/riscv
-          make -j $(nproc) ${{ matrix.mode }}
+          make -j $(nproc) "$MATRIX_MODE"
       - name: build simulator
         if: |
           matrix.build-sim == true

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -262,11 +262,13 @@ jobs:
         run: |
           make -j $(nproc) build-sim
       - name: make report
+        # Skip newlib multilib report which overruns the 6h job limit
         if: |
           matrix.os == 'ubuntu-24.04'
           && (matrix.mode == 'linux' || matrix.mode == 'newlib')
           && matrix.compiler == 'gcc'
           && matrix.report == true
+          && !(matrix.mode == 'newlib' && matrix.baremetal-multilib != '')
         run: |
           make report-${{ matrix.mode }} -j $(nproc)
 

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -365,13 +365,15 @@ jobs:
           matrix.build-sim == true
         run: |
           make -j $(nproc) build-sim
+      # Skip report for newlib multilib builds: running the full testsuite
+      # across every multilib variant overruns the 6h job limit. Non-multilib
+      # newlib and linux builds get reports.
       - name: make report
         if: |
           matrix.os == 'ubuntu-24.04'
-          && (matrix.mode == 'linux' || matrix.mode == 'newlib')
+          && (matrix.mode == 'linux' || (matrix.mode == 'newlib' && matrix.multilib-generator == ''))
           && matrix.compiler == 'gcc'
           && matrix.report == true
-          && matrix.multilib-generator == ''  # multilib report overruns the 6h job limit
         run: |
           make report-${{ matrix.mode }} -j $(nproc)
 

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -291,29 +291,37 @@ jobs:
           path: prebuilt-gnu
 
       - name: Configure toolchain
+        env:
+          MATRIX_MODE: ${{ matrix.mode }}
+          MATRIX_COMPILER: ${{ matrix.compiler }}
+          MATRIX_TARGET: ${{ matrix.target }}
+          MATRIX_MULTILIB_GENERATOR: ${{ matrix.multilib-generator }}
+          MATRIX_SIM: ${{ matrix.sim }}
+          MATRIX_CMODEL: ${{ matrix.cmodel }}
+          MATRIX_LANGUAGES: ${{ matrix.languages }}
+          MATRIX_STRIP: ${{ matrix.strip }}
         run: |
-          TARGET_TUPLE=($(echo ${{ matrix.target }} | tr "-" "\n"))
-          BUILD_TOOLCHAIN="./configure --prefix=/mnt/riscv --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]}"
-          ARGS=""
-          if [ "${{ matrix.mode }}" == "newlib" ] && [ "${{ matrix.compiler }}" != "llvm" ] && [ -n "${{ matrix.multilib-generator }}" ]; then
-            ARGS="$ARGS --with-multilib-generator=\"${{ matrix.multilib-generator }}\""
+          TARGET_TUPLE=($(echo "$MATRIX_TARGET" | tr "-" "\n"))
+          ARGS=(--prefix=/mnt/riscv --with-arch="${TARGET_TUPLE[0]}" --with-abi="${TARGET_TUPLE[1]}")
+          if [ "$MATRIX_MODE" == "newlib" ] && [ "$MATRIX_COMPILER" != "llvm" ] && [ -n "$MATRIX_MULTILIB_GENERATOR" ]; then
+            ARGS+=(--with-multilib-generator="$MATRIX_MULTILIB_GENERATOR")
           fi
-          if [ "${{ matrix.compiler }}" == "llvm" ]; then # build toolchain with llvm
-            ARGS="$ARGS --enable-llvm"
+          if [ "$MATRIX_COMPILER" == "llvm" ]; then # build toolchain with llvm
+            ARGS+=(--enable-llvm)
           fi
-          if [ -n "${{ matrix.sim }}" ]; then
-            ARGS="$ARGS --with-sim=${{ matrix.sim }}"
+          if [ -n "$MATRIX_SIM" ]; then
+            ARGS+=(--with-sim="$MATRIX_SIM")
           fi
-          if [ -n "${{ matrix.cmodel }}" ]; then
-            ARGS="$ARGS --with-cmodel=${{ matrix.cmodel }}"
+          if [ -n "$MATRIX_CMODEL" ]; then
+            ARGS+=(--with-cmodel="$MATRIX_CMODEL")
           fi
-          if [ -n "${{ matrix.languages }}" ]; then
-            ARGS="$ARGS --with-languages=${{ matrix.languages }}"
+          if [ -n "$MATRIX_LANGUAGES" ]; then
+            ARGS+=(--with-languages="$MATRIX_LANGUAGES")
           fi
-          if [ "${{ matrix.strip }}" = "true" ]; then
-            ARGS="$ARGS --enable-strip"
+          if [ "$MATRIX_STRIP" = "true" ]; then
+            ARGS+=(--enable-strip)
           fi
-          $BUILD_TOOLCHAIN $ARGS
+          ./configure "${ARGS[@]}"
           sudo mkdir /mnt/riscv
           sudo chown runner:runner /mnt/riscv
 
@@ -330,7 +338,9 @@ jobs:
 
       - name: Build toolchain
         if: ${{ !inputs.use-prebuilt-gnu }}
-        run: make -j $(nproc) ${{ matrix.mode }}
+        env:
+          MATRIX_MODE: ${{ matrix.mode }}
+        run: make -j $(nproc) "$MATRIX_MODE"
 
       # Build the LLVM stamp directly instead of the "<mode>" aggregate, so that
       # this does not have to track whatever else "<mode>" pulls in. The only
@@ -361,6 +371,7 @@ jobs:
           && (matrix.mode == 'linux' || matrix.mode == 'newlib')
           && matrix.compiler == 'gcc'
           && matrix.report == true
+          && matrix.multilib-generator == ''  # multilib report overruns the 6h job limit
         run: |
           make report-${{ matrix.mode }} -j $(nproc)
 

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -53,6 +53,10 @@ on:
           top of it. Requires compiler '["llvm"]'.
         type: boolean
         default: false
+      multilib-generator:
+        description: "Multilib generator string passed to --with-multilib-generator (newlib only)"
+        type: string
+        default: ""
 
 env:
   submodule_paths: |
@@ -184,6 +188,8 @@ jobs:
           - ${{ inputs.report }}
         build-sim:
           - ${{ inputs.build-sim }}
+        multilib-generator:
+          - ${{ inputs.multilib-generator }}
 
         exclude:
           - mode: uclibc
@@ -289,6 +295,9 @@ jobs:
           TARGET_TUPLE=($(echo ${{ matrix.target }} | tr "-" "\n"))
           BUILD_TOOLCHAIN="./configure --prefix=/mnt/riscv --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]}"
           ARGS=""
+          if [ "${{ matrix.mode }}" == "newlib" ] && [ "${{ matrix.compiler }}" != "llvm" ] && [ -n "${{ matrix.multilib-generator }}" ]; then
+            ARGS="$ARGS --with-multilib-generator=\"${{ matrix.multilib-generator }}\""
+          fi
           if [ "${{ matrix.compiler }}" == "llvm" ]; then # build toolchain with llvm
             ARGS="$ARGS --enable-llvm"
           fi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,12 +45,3 @@ jobs:
       target: '["rv64gc-lp64d"]'
       sim: '["spike"]'
 
-  build-multilib:
-    if: ${{ false }} # Disable until multilib errors are triaged
-    uses: ./.github/workflows/build-reusable.yaml
-    with:
-      artifact-name: multilib
-      os: '["ubuntu-24.04"]'
-      mode: '["newlib","linux"]'
-      target: '["rv64gc-lp64d"]'
-

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -58,6 +58,23 @@ jobs:
     with:
       compiler: '["gcc"]'
 
+  # A separate, multilib newlib toolchain, published alongside the plain rv32
+  # and rv64 newlib packages from the 'build' job above (which stay single-lib).
+  # Only one row is built: the library set is defined entirely by the generator
+  # string, so --with-arch/abi no longer selects it and a second target would
+  # just duplicate the same multilib. 'artifact-name: multilib' keeps its name
+  # distinct from the plain rv64 newlib package.
+  build-multilib:
+    needs: [activity-check]
+    if: needs.activity-check.outputs.stale != 'true'
+    uses: ./.github/workflows/build-reusable.yaml
+    with:
+      artifact-name: multilib
+      compiler: '["gcc"]'
+      mode: '["newlib"]'
+      target: '["rv64gc-lp64d"]'
+      multilib-generator: "rv32i-ilp32--c;rv32im-ilp32--c;rv32iac-ilp32--;rv32imac-ilp32--;rv32imafc-ilp32f-rv32imafdc-;rv64imac-lp64--;rv64imafdc-lp64d--;--cmodel;medany,large"
+
   # Builds LLVM on top of the GNU toolchain produced above, see build.yaml.
   build-llvm:
     needs: [build]
@@ -67,7 +84,7 @@ jobs:
       use-prebuilt-gnu: true
 
   create-release:
-    needs: [build, build-llvm]
+    needs: [build, build-multilib, build-llvm]
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/Makefile.in
+++ b/Makefile.in
@@ -20,6 +20,7 @@ LLVM_GENERATOR ?= Ninja
 # and pass it to ninja; else ninja uses all cores. Unix Makefiles gets -jN from
 # the `+` recipe lines below, so it must not get -jN here.
 LLVM_PARALLEL_JOBS ?= $(patsubst -j%,%,$(filter -j%,$(MAKEFLAGS)))
+LLVM_PARALLEL_LINK_JOBS ?= 4
 ifeq ($(LLVM_GENERATOR),Ninja)
 LLVM_BUILD_TOOL = ninja $(if $(LLVM_PARALLEL_JOBS),-j$(LLVM_PARALLEL_JOBS)) -C
 else
@@ -35,7 +36,7 @@ LLVM_LINUX_COMMON_CMAKE_FLAGS = \
     -DDEFAULT_SYSROOT="../sysroot" \
     -DLLVM_INSTALL_TOOLCHAIN_ONLY=On \
     -DLLVM_BINUTILS_INCDIR=$(BINUTILS_SRCDIR)/include \
-    -DLLVM_PARALLEL_LINK_JOBS=4
+    -DLLVM_PARALLEL_LINK_JOBS=$(LLVM_PARALLEL_LINK_JOBS)
 define LLVM_BUILD_OPENMP
 	if test $(XLEN) -eq 64; then \
 	    mkdir $(notdir $@)/openmp-shared; \
@@ -1326,7 +1327,7 @@ stamps/build-llvm-newlib: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BI
 	    -DLLVM_DEFAULT_TARGET_TRIPLE="$(NEWLIB_TUPLE)" \
 	    -DLLVM_INSTALL_TOOLCHAIN_ONLY=On \
 	    -DLLVM_BINUTILS_INCDIR=$(BINUTILS_SRCDIR)/include \
-	    -DLLVM_PARALLEL_LINK_JOBS=4 \
+	    -DLLVM_PARALLEL_LINK_JOBS=$(LLVM_PARALLEL_LINK_JOBS) \
 	    $(LLVM_EXTRA_CONFIGURE_FLAGS)
 	+$(LLVM_BUILD_TOOL) $(notdir $@)
 	+$(LLVM_BUILD_TOOL) $(notdir $@) $(subst -,/,$(INSTALL_TARGET))


### PR DESCRIPTION
NOTE: LLVM does not support multilib, so skip --with-multilib-generator
when compiler is llvm, this will result in the released toolchain package containing LLVM not including multilib generators with different code models.