### PR TITLE
Disable shallow clones for Binutils and GDB

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -116,9 +116,7 @@ jobs:
 
       - name: Checkout required submodules
         if: steps.smcache.outputs.cache-hit != 'true'
-        run: |
-          git submodule update --init dejagnu
-          git submodule update --init -j $(nproc) --depth 1 $(git submodule | awk '$2 != "dejagnu" {print $2}')
+        run: git submodule update --init -j $(nproc)
 
       - name: Storage size optimization
         if: steps.smcache.outputs.cache-hit != 'true'

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
 	path = binutils
 	url = https://sourceware.org/git/binutils-gdb.git
 	branch = binutils-2_46-branch
-	shallow = true
+	shallow = false
 [submodule "gcc"]
 	path = gcc
 	url = https://github.com/gcc-mirror/gcc.git
@@ -25,8 +25,8 @@
 [submodule "gdb"]
 	path = gdb
 	url = https://sourceware.org/git/binutils-gdb.git
-	branch = gdb-16-branch
-	shallow = true
+	branch = gdb-17-branch
+	shallow = false
 [submodule "qemu"]
 	path = qemu
 	url = https://gitlab.com/qemu-project/qemu.git

--- a/Makefile.in
+++ b/Makefile.in
@@ -471,7 +471,7 @@ endif
 $(srcdir)/%/.git:
 	cd $(srcdir) && \
 	flock `git rev-parse --git-dir`/config git submodule init $(dir $@) && \
-	flock `git rev-parse --git-dir`/config git submodule update --progress --depth 1 $(dir $@)
+	flock `git rev-parse --git-dir`/config git submodule update --progress $(dir $@)
 
 stamps/install-host-gcc: $(GCC_SRCDIR) $(GCC_SRC_GIT)
 	if test -f $</contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" = "true"; then cd $< && ./contrib/download_prerequisites; fi


### PR DESCRIPTION
Currently shallow clones for Binutils and GDB often cause submodule fetch errors.
Disable using shallow clones in these submodules and sync GDB to the latest release tag.

Reported by https://github.com/riscv-collab/riscv-gnu-toolchain/issues/1881