### PR TITLE
Select the default libc, guard unsupported combos, and tidy up

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -302,8 +302,16 @@ build-gcc%: stamps/build-gcc-@default_target@-stage%
 ifeq (@default_target@,linux)
 build-libc: $(addprefix stamps/build-glibc-linux-,$(GLIBC_MULTILIB_NAMES))
 else
+ifeq (@default_target@,musl)
+build-libc: stamps/build-musl-linux
+else
+ifeq (@default_target@,uclibc)
+build-libc: stamps/build-uclibc-linux
+else
 build-libc: stamps/build-newlib stamps/build-newlib-nano \
 	stamps/merge-newlib-nano
+endif
+endif
 endif
 build-qemu: stamps/build-qemu
 build-llvm: stamps/build-llvm-@default_target@

--- a/Makefile.in
+++ b/Makefile.in
@@ -196,8 +196,8 @@ ENDIAN_POSTFIX := be
 endif
 
 make_tuple = riscv$(1)$(ENDIAN_POSTFIX)-unknown-$(2)
-LINUX_TUPLE  ?= $(call make_tuple,$(XLEN),linux-gnu)
 NEWLIB_TUPLE ?= $(call make_tuple,$(XLEN),elf)
+LINUX_TUPLE  ?= $(call make_tuple,$(XLEN),linux-gnu)
 MUSL_TUPLE ?= $(call make_tuple,$(XLEN),linux-musl)
 UCLIBC_TUPLE ?= $(call make_tuple,$(XLEN),linux-uclibc)
 
@@ -230,15 +230,6 @@ BINUTILS_NATIVE_FLAGS := $(BINUTILS_NATIVE_FLAGS_EXTRA)
 GDB_TARGET_FLAGS := --with-expat=yes $(GDB_TARGET_FLAGS_EXTRA)
 GDB_NATIVE_FLAGS := $(GDB_NATIVE_FLAGS_EXTRA)
 
-GLIBC_TARGET_FLAGS := $(GLIBC_TARGET_FLAGS_EXTRA)
-GLIBC_CC_FOR_TARGET ?= $(LINUX_TUPLE)-gcc
-GLIBC_CXX_FOR_TARGET ?= $(LINUX_TUPLE)-g++
-GLIBC_TARGET_BOARDS ?= $(shell $(srcdir)/scripts/generate_target_board \
-  --sim-name riscv-sim \
-  --cmodel $(shell echo @cmodel@ | cut -d '=' -f2) \
-  --build-arch-abi "$(GLIBC_MULTILIB_NAMES)" \
-  --extra-test-arch-abi-flags-list "$(EXTRA_MULTILIB_TEST)")
-
 NEWLIB_TARGET_FLAGS := $(NEWLIB_TARGET_FLAGS_EXTRA)
 NEWLIB_CC_FOR_TARGET ?= $(NEWLIB_TUPLE)-gcc
 NEWLIB_CXX_FOR_TARGET ?= $(NEWLIB_TUPLE)-g++
@@ -254,6 +245,15 @@ NEWLIB_NANO_TARGET_BOARDS ?= $(shell $(srcdir)/scripts/generate_target_board \
   --build-arch-abi "$(NEWLIB_MULTILIB_NAMES)" \
   --extra-test-arch-abi-flags-list "$(EXTRA_MULTILIB_TEST)")
 NEWLIB_CC_FOR_MULTILIB_INFO := $(NEWLIB_CC_FOR_TARGET)
+
+GLIBC_TARGET_FLAGS := $(GLIBC_TARGET_FLAGS_EXTRA)
+GLIBC_CC_FOR_TARGET ?= $(LINUX_TUPLE)-gcc
+GLIBC_CXX_FOR_TARGET ?= $(LINUX_TUPLE)-g++
+GLIBC_TARGET_BOARDS ?= $(shell $(srcdir)/scripts/generate_target_board \
+  --sim-name riscv-sim \
+  --cmodel $(shell echo @cmodel@ | cut -d '=' -f2) \
+  --build-arch-abi "$(GLIBC_MULTILIB_NAMES)" \
+  --extra-test-arch-abi-flags-list "$(EXTRA_MULTILIB_TEST)")
 
 MUSL_TARGET_FLAGS := $(MUSL_TARGET_FLAGS_EXTRA)
 MUSL_CC_FOR_TARGET ?= $(MUSL_TUPLE)-gcc

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 RISC-V GNU Compiler Toolchain
 =============================
 
-This is the RISC-V C and C++ cross-compiler. It supports two build modes:
-a generic ELF/Newlib toolchain and a more sophisticated Linux-ELF/glibc
-toolchain.
+This is the RISC-V C and C++ cross-compiler. It can build a bare-metal
+ELF toolchain (using Newlib) or a Linux-ELF toolchain (using glibc, musl,
+or uClibc).
 
 ###  Getting the sources
 
@@ -47,36 +47,35 @@ upstream sources exists in $(DISTDIR), it will be used; the default location
 is /var/cache/distfiles.  Your computer will need about 8 GiB of disk space to
 complete the process.
 
-### Installation (Newlib)
+### Installation
 
-To build the Newlib cross-compiler, pick an install path (that is writeable).
-If you choose, say, `/opt/riscv`, then add `/opt/riscv/bin` to your `PATH`.
-Then, simply run the following command:
-
-    ./configure --prefix=/opt/riscv
-    make
-
-You should now be able to use riscv64-unknown-elf-gcc and its cousins.
-
-Note: If you're planning to use an external library that replaces part of newlib (for example `libgloss-htif`), [read the FAQ](#ensuring-code-model-consistency).
-
-### Installation (Linux)
-
-To build the Linux cross-compiler, pick an install path (that is writeable).
-If you choose, say, `/opt/riscv`, then add `/opt/riscv/bin` to your `PATH`.
-Then, simply run the following command:
+Pick an install path that is writeable — say `/opt/riscv` — and add
+`/opt/riscv/bin` to your `PATH`.  Then configure:
 
     ./configure --prefix=/opt/riscv
-    make linux
 
-The build defaults to targeting RV64GC (64-bit) with glibc, even on a 32-bit
-build environment. To build the 32-bit RV32GC toolchain, use:
+and build the C library you want:
+
+| C library      | build         |
+| -------------- | ------------- |
+| Newlib         | `make`        |
+| Linux (glibc)  | `make linux`  |
+| Linux (musl)   | `make musl`   |
+| Linux (uClibc) | `make uclibc` |
+
+You should now be able to use, e.g., `riscv64-unknown-elf-gcc` and its
+cousins.  The bare-metal (Newlib) tools are prefixed `riscv64-unknown-elf-`,
+the Linux tools `riscv64-unknown-linux-{gnu,musl,uclibc}-`.
+
+A plain `make` builds the default target, which is Newlib.  To make a
+different libc the default — so that `make` on its own builds it — configure
+with `--enable-newlib`, `--enable-linux`, `--enable-musl` or
+`--enable-uclibc`.
+
+The build defaults to targeting RV64GC (64-bit), even on a 32-bit build
+environment.  To build a 32-bit toolchain, pass the arch and ABI, e.g.:
 
     ./configure --prefix=/opt/riscv --with-arch=rv32gc --with-abi=ilp32d
-    make linux
-
-In case you prefer musl libc over glibc, configure just like above and opt for
-`make musl` instead of `make linux`.
 
 Supported architectures are rv32i or rv64i plus standard extensions (a)tomics,
 (m)ultiplication and division, (f)loat, (d)ouble, or (g)eneral for MAFD.
@@ -85,21 +84,24 @@ Supported ABIs are ilp32 (32-bit soft-float), ilp32d (32-bit hard-float),
 ilp32f (32-bit with single-precision in registers and double in memory, niche
 use only), lp64 lp64f lp64d (same but with 64-bit long and pointers).
 
-### Installation (Newlib/Linux multilib)
+Note: If you're planning to use an external library that replaces part of newlib (for example `libgloss-htif`), [read the FAQ](#ensuring-code-model-consistency).
 
-To build either cross-compiler with support for both 32-bit and
-64-bit, run the following command:
+### Multilib
+
+Add `--enable-multilib` to build runtime libraries for both 32-bit and
+64-bit:
 
     ./configure --prefix=/opt/riscv --enable-multilib
 
-And then either `make`, `make linux` or `make musl` for the Newlib, Linux
-glibc-based or Linux musl libc-based cross-compiler, respectively.
+The resulting compiler can target both 32-bit and 64-bit systems and
+supports the most common `-march`/`-mabi` options, which can be seen with
+the `--print-multi-lib` flag.
 
-The multilib compiler will have the prefix riscv64-unknown-elf- or
-riscv64-unknown-linux-gnu- but will be able to target both 32-bit and 64-bit
-systems.
-It will support the most common `-march`/`-mabi` options, which can be seen by
-using the `--print-multi-lib` flag on either cross-compiler.
+Multilib is only available for the Newlib and Linux/glibc toolchains; the
+musl and uClibc toolchains build a single variant, and configuring them
+with `--enable-multilib` is rejected.  Building them explicitly (e.g.
+`make musl`) in a tree configured for multilib still yields a single
+variant.
 
 Linux toolchain has an additional option `--enable-default-pie` to control the
 default PIE enablement for GCC, which is disable by default.
@@ -256,6 +258,9 @@ by the SIM variable in the Makefile, e.g. SIM=qemu, SIM=gdb, or SIM=spike
 (experimental).In addition, the simulator can also be selected with the
 configure time option `--with-sim=`.However, the testsuite allowlist is
 only maintained for qemu.Other simulators might get extra failures.
+
+The `make check` and `make report` targets are wired only for the Newlib
+and Linux/glibc toolchains.
 
 #### Additional Prerequisite
 

--- a/configure
+++ b/configure
@@ -718,7 +718,10 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+enable_newlib
 enable_linux
+enable_musl
+enable_uclibc
 enable_debug_info
 enable_default_pie
 with_arch
@@ -1384,8 +1387,14 @@ Optional Features:
   --disable-option-checking  ignore unrecognized --enable/--with options
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
+  --enable-newlib         set newlib as the default make target
+                          [--disable-newlib]
   --enable-linux          set linux as the default make target
                           [--disable-linux]
+  --enable-musl           set musl as the default make target
+                          [--disable-musl]
+  --enable-uclibc         set uclibc as the default make target
+                          [--disable-uclibc]
   --enable-debug-info     build glibc/musl/newlibc/libgcc with debug
                           information
   --enable-default-pie    build linux toolchain with default PIE
@@ -3932,10 +3941,31 @@ else $as_nop
 fi
 
 
+# Check whether --enable-newlib was given.
+if test ${enable_newlib+y}
+then :
+  enableval=$enable_newlib;
+fi
+
+
 # Check whether --enable-linux was given.
 if test ${enable_linux+y}
 then :
   enableval=$enable_linux;
+fi
+
+
+# Check whether --enable-musl was given.
+if test ${enable_musl+y}
+then :
+  enableval=$enable_musl;
+fi
+
+
+# Check whether --enable-uclibc was given.
+if test ${enable_uclibc+y}
+then :
+  enableval=$enable_uclibc;
 fi
 
 
@@ -3944,8 +3974,26 @@ then :
   default_target=linux
 
 else $as_nop
+  if test "x$enable_musl" = xyes
+then :
+  default_target=musl
+
+else $as_nop
+  if test "x$enable_uclibc" = xyes
+then :
+  default_target=uclibc
+
+else $as_nop
+  if test "x$enable_newlib" = xyes
+then :
   default_target=newlib
 
+else $as_nop
+  default_target=newlib
+
+fi
+fi
+fi
 fi
 
 # Check whether --enable-debug_info was given.

--- a/configure
+++ b/configure
@@ -4394,6 +4394,31 @@ else $as_nop
 
 fi
 
+# The musl and uClibc toolchains build a single-variant GCC
+# (--disable-multilib) and wire no per-variant runtime, so multilib is not
+# available for them.  Reject it rather than silently ignoring the request.
+if test "x$multilib_flags" = x--enable-multilib
+then :
+  case $default_target in #(
+  musl | uclibc) :
+    as_fn_error $? "multilib is not supported for the $default_target toolchain" "$LINENO" 5 ;; #(
+  *) :
+     ;;
+esac
+fi
+
+# There is no Clang runtime build for the uClibc toolchain, so --enable-llvm
+# would configure cleanly and then fail at make time.  Reject it up front.
+if test "x$enable_llvm" = x--enable-llvm
+then :
+  case $default_target in #(
+  uclibc) :
+    as_fn_error $? "LLVM is not supported for the $default_target toolchain" "$LINENO" 5 ;; #(
+  *) :
+     ;;
+esac
+fi
+
 # Check whether --enable-host-gcc was given.
 if test ${enable_host_gcc+y}
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -40,12 +40,30 @@ AS_IF([test x"$CURL" != xno], [FETCHER="$CURL -L -o - --ftp-pasv --retry 10"],
 	[AC_MSG_ERROR([no file transfer utility found])])
 AC_SUBST(FETCHER)
 
+AC_ARG_ENABLE(newlib,
+	[AS_HELP_STRING([--enable-newlib],
+		[set newlib as the default make target @<:@--disable-newlib@:>@])])
+
 AC_ARG_ENABLE(linux,
 	[AS_HELP_STRING([--enable-linux],
 		[set linux as the default make target @<:@--disable-linux@:>@])])
 
+AC_ARG_ENABLE(musl,
+	[AS_HELP_STRING([--enable-musl],
+		[set musl as the default make target @<:@--disable-musl@:>@])])
+
+AC_ARG_ENABLE(uclibc,
+	[AS_HELP_STRING([--enable-uclibc],
+		[set uclibc as the default make target @<:@--disable-uclibc@:>@])])
+
 AS_IF([test "x$enable_linux" = xyes],
 	[AC_SUBST(default_target, linux)],
+	[test "x$enable_musl" = xyes],
+	[AC_SUBST(default_target, musl)],
+	[test "x$enable_uclibc" = xyes],
+	[AC_SUBST(default_target, uclibc)],
+	[test "x$enable_newlib" = xyes],
+	[AC_SUBST(default_target, newlib)],
 	[AC_SUBST(default_target, newlib)])
 
 AC_ARG_ENABLE(debug_info,

--- a/configure.ac
+++ b/configure.ac
@@ -279,6 +279,21 @@ AS_IF([test "x$enable_llvm" = xyes],
 	[AC_SUBST(enable_llvm, --enable-llvm)],
 	[AC_SUBST(enable_llvm, --disable-llvm)])
 
+# The musl and uClibc toolchains build a single-variant GCC
+# (--disable-multilib) and wire no per-variant runtime, so multilib is not
+# available for them.  Reject it rather than silently ignoring the request.
+AS_IF([test "x$multilib_flags" = x--enable-multilib],
+	[AS_CASE([$default_target],
+		[musl | uclibc],
+		[AC_MSG_ERROR([multilib is not supported for the $default_target toolchain])])])
+
+# There is no Clang runtime build for the uClibc toolchain, so --enable-llvm
+# would configure cleanly and then fail at make time.  Reject it up front.
+AS_IF([test "x$enable_llvm" = x--enable-llvm],
+	[AS_CASE([$default_target],
+		[uclibc],
+		[AC_MSG_ERROR([LLVM is not supported for the $default_target toolchain])])])
+
 AC_ARG_ENABLE(host-gcc,
 	[AS_HELP_STRING([--enable-host-gcc],
 		[Build host GCC to build cross toolchain])])


### PR DESCRIPTION
Preparatory cleanup for picolibc.
It makes every bundled libc a first-class default make target,
rejects feature/libc combinations that cannot work, and tidies
the Makefile and README. No functional change for the existing
default (newlib) or Linux builds.

## Commits

1. **Allow selecting the default libc with `--enable-{newlib,musl,uclibc}`**
   The default make target could previously only be switched to Linux/glibc
   (`--enable-linux`); newlib was the hard-coded fallback and musl/uClibc could
   only be built through their explicit `make musl` / `make uclibc` targets.
   Add `--enable-newlib`, `--enable-musl` and `--enable-uclibc` so any bundled
   libc can be the default and built with a plain `make`. Also teach the
   `build-libc` staged target to build musl/uClibc instead of falling through
   to newlib.

2. **README: streamline the installation instructions**
   Fold the near-identical per-libc install sections into a single table (and
   document uClibc, which had no section). Correct the intro, state that Newlib
   is the default target, trim the multilib section, and document that multilib
   and the `check`/`report` targets are only available for the Newlib and
   Linux/glibc toolchains.

3. **Makefile: order the per-libc variables consistently**
   `*_TUPLE` and `*_TARGET_FLAGS` used a different order than `*_SRC_GIT` and
   the build targets. Put them all in the same order.

4. **configure: reject unsupported multilib and LLVM default targets**
   The musl and uClibc toolchains build GCC with `--disable-multilib` and wire
   no per-variant runtime, so `--enable-multilib` was silently ignored — the
   user asked for a multilib toolchain and quietly got a single-variant one.
   Likewise `--enable-llvm` has no build rule for the uClibc toolchain, so it
   configured cleanly and then failed at make time. Reject both up front.

## Testing

Configure-level smoke tests only (no behavioural change to builds):

- `./configure --enable-{newlib,linux,musl,uclibc}` each selects the matching
  default target (`all: <libc>`); no flag defaults to newlib.
- `--enable-{musl,uclibc} --enable-multilib` and `--enable-uclibc --enable-llvm`
  now error; `--enable-multilib` (newlib default), `--enable-linux
  --enable-multilib`, and `--enable-musl --enable-llvm` still pass.
- `make build-libc` builds the selected libc for musl/uClibc.