### PR TITLE
Add Picolibc support

### DIFF
--- a/.github/setup-apt.sh
+++ b/.github/setup-apt.sh
@@ -5,6 +5,6 @@ apt update
 apt install -y autoconf automake autotools-dev curl python3 python3-pip \
             python3-tomli libmpc-dev libmpfr-dev libgmp-dev gawk \
             build-essential bison flex texinfo gperf libtool patchutils bc \
-            zlib1g-dev libexpat-dev git ninja-build cmake ccache libglib2.0-dev \
+            zlib1g-dev libexpat-dev git meson ninja-build cmake ccache libglib2.0-dev \
             expect device-tree-compiler python3-pyelftools libslirp-dev \
             libzstd-dev libncurses-dev

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -13,7 +13,7 @@ on:
       mode:
         description: "Mode list"
         type: string
-        default: '["newlib","linux","musl","uclibc"]'
+        default: '["newlib","linux","musl","uclibc","picolibc"]'
       target:
         description: "Target list"
         type: string
@@ -64,6 +64,7 @@ env:
     llvm
     musl
     newlib
+    picolibc
     pk
     qemu
     spike
@@ -187,6 +188,8 @@ jobs:
         exclude:
           - mode: uclibc
             compiler: llvm
+          - mode: picolibc
+            compiler: llvm
     outputs:
       toolchain-name: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}
     steps:
@@ -203,6 +206,8 @@ jobs:
               MODE="musl";;
             "uclibc")
               MODE="uclibc-ng";;
+            "picolibc")
+              MODE="elf-picolibc";;
             *)
               MODE="elf";;
           esac

--- a/.gitmodules
+++ b/.gitmodules
@@ -55,3 +55,7 @@
 	path = uclibc-ng
 	url = https://github.com/wbx-github/uclibc-ng.git
 	shallow = true
+[submodule "picolibc"]
+	path = picolibc
+	url = https://github.com/picolibc/picolibc.git
+	shallow = true

--- a/Makefile.in
+++ b/Makefile.in
@@ -5,6 +5,7 @@ INSTALL_DIR := @prefix@
 GCC_SRCDIR := @with_gcc_src@
 BINUTILS_SRCDIR := @with_binutils_src@
 NEWLIB_SRCDIR := @with_newlib_src@
+PICOLIBC_SRCDIR := @with_picolibc_src@
 GLIBC_SRCDIR := @with_glibc_src@
 MUSL_SRCDIR := @with_musl_src@
 UCLIBC_SRCDIR := @with_uclibc_src@
@@ -199,6 +200,7 @@ endif
 
 make_tuple = riscv$(1)$(ENDIAN_POSTFIX)-unknown-$(2)
 NEWLIB_TUPLE ?= $(call make_tuple,$(XLEN),elf)
+PICOLIBC_TUPLE ?= $(call make_tuple,$(XLEN),elf)
 LINUX_TUPLE  ?= $(call make_tuple,$(XLEN),linux-gnu)
 MUSL_TUPLE ?= $(call make_tuple,$(XLEN),linux-musl)
 UCLIBC_TUPLE ?= $(call make_tuple,$(XLEN),linux-uclibc)
@@ -249,6 +251,8 @@ NEWLIB_NANO_TARGET_BOARDS ?= $(shell $(srcdir)/scripts/generate_target_board \
   --extra-test-arch-abi-flags-list "$(EXTRA_MULTILIB_TEST)")
 NEWLIB_CC_FOR_MULTILIB_INFO := $(NEWLIB_CC_FOR_TARGET)
 
+PICOLIBC_TARGET_FLAGS := $(PICOLIBC_TARGET_FLAGS_EXTRA)
+
 GLIBC_TARGET_FLAGS := $(GLIBC_TARGET_FLAGS_EXTRA)
 GLIBC_CC_FOR_TARGET ?= $(LINUX_TUPLE)-gcc
 GLIBC_CXX_FOR_TARGET ?= $(LINUX_TUPLE)-g++
@@ -279,11 +283,13 @@ PATH := $(builddir)/install-host-gcc/bin:$(PATH)
 GCC_CHECKING_FLAGS := $(GCC_CHECKING_FLAGS) --enable-werror-always
 endif
 newlib: stamps/build-gcc-newlib-stage2
+picolibc: stamps/build-gcc-picolibc-stage2
 linux: stamps/build-gcc-linux-stage2
 musl: stamps/build-gcc-musl-stage2
 uclibc: stamps/build-gcc-uclibc-stage2
 ifeq (@enable_gdb@,--enable-gdb)
 newlib: stamps/build-gdb-newlib
+picolibc: stamps/build-gdb-picolibc
 linux: stamps/build-gdb-linux
 musl: stamps/build-gdb-musl
 endif
@@ -311,8 +317,12 @@ else
 ifeq (@default_target@,uclibc)
 build-libc: stamps/build-uclibc-linux
 else
+ifeq (@default_target@,picolibc)
+build-libc: stamps/build-picolibc
+else
 build-libc: stamps/build-newlib stamps/build-newlib-nano \
 	stamps/merge-newlib-nano
+endif
 endif
 endif
 endif
@@ -436,6 +446,12 @@ ifeq ($(findstring $(srcdir),$(NEWLIB_SRCDIR)),$(srcdir))
 NEWLIB_SRC_GIT := $(NEWLIB_SRCDIR)/.git
 else
 NEWLIB_SRC_GIT :=
+endif
+
+ifeq ($(findstring $(srcdir),$(PICOLIBC_SRCDIR)),$(srcdir))
+PICOLIBC_SRC_GIT := $(PICOLIBC_SRCDIR)/.git
+else
+PICOLIBC_SRC_GIT :=
 endif
 
 ifeq ($(findstring $(srcdir),$(GLIBC_SRCDIR)),$(srcdir))
@@ -930,6 +946,118 @@ stamps/build-gcc-newlib-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-newlib
 		$(WITH_ARCH) \
 		$(WITH_TUNE) \
 		$(WITH_ISA_SPEC) \
+		$(GCC_WITH_SPECS) \
+		$(GCC_EXTRA_CONFIGURE_FLAGS) \
+		CFLAGS_FOR_TARGET="-Os $(CFLAGS_FOR_TARGET)" \
+		CXXFLAGS_FOR_TARGET="-Os $(CXXFLAGS_FOR_TARGET)"
+	$(MAKE) -C $(notdir $@)
+	$(MAKE) -C $(notdir $@) $(INSTALL_TARGET)
+	mkdir -p $(dir $@) && touch $@
+
+#
+# PICOLIBC
+#
+
+# Picolibc shares the bare-metal ELF target tuple with newlib, so its
+# binutils and gdb builds are identical.  Reuse the newlib ones instead
+# of building the same tools twice.
+stamps/build-binutils-picolibc: stamps/build-binutils-newlib
+	mkdir -p $(dir $@) && touch $@
+
+stamps/build-gdb-picolibc: stamps/build-gdb-newlib
+	mkdir -p $(dir $@) && touch $@
+
+GCC_PICOLIBC_CONFIGURE_FLAGS = \
+		--target=$(PICOLIBC_TUPLE) \
+		$(CONFIGURE_HOST) \
+		--prefix=$(INSTALL_DIR) \
+		--disable-shared \
+		--disable-threads \
+		@with_system_zlib@ \
+		--enable-tls \
+		--with-newlib \
+		--with-picolibc \
+		--with-sysroot=$(INSTALL_DIR)/$(PICOLIBC_TUPLE) \
+		--disable-libmudflap \
+		--disable-libssp \
+		--disable-libquadmath \
+		--disable-libgomp \
+		--disable-nls \
+		--disable-tm-clone-registry \
+		--src=$(gccsrcdir) \
+		$(GCC_CHECKING_FLAGS) \
+		--disable-multilib \
+		$(WITH_ABI) \
+		$(WITH_ARCH) \
+		$(WITH_TUNE) \
+		$(WITH_ISA_SPEC)
+
+stamps/build-gcc-picolibc-stage1: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-binutils-picolibc
+	if test -f $</contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" = "true"; then cd $< && ./contrib/download_prerequisites; fi
+	rm -rf $@ $(notdir $@)
+	mkdir $(notdir $@)
+	cd $(notdir $@) && $</configure \
+		$(GCC_PICOLIBC_CONFIGURE_FLAGS) \
+		--enable-languages=c,c++ \
+		$(GCC_EXTRA_CONFIGURE_FLAGS) \
+		CFLAGS_FOR_TARGET="-Os $(CFLAGS_FOR_TARGET)" \
+		CXXFLAGS_FOR_TARGET="-Os $(CXXFLAGS_FOR_TARGET)"
+	$(MAKE) -C $(notdir $@) all-gcc
+	$(MAKE) -C $(notdir $@) $(INSTALL_TARGET)-gcc
+	mkdir -p $(dir $@) && touch $@
+
+# Meson needs a cross file describing the toolchain; generate it inline
+# from the target tuple.  Target flags (code model included) come from
+# CFLAGS_FOR_TARGET, plus picolibc's own -msave-restore and -fno-common.
+stamps/build-picolibc: $(PICOLIBC_SRCDIR) $(PICOLIBC_SRC_GIT) stamps/build-gcc-picolibc-stage1
+	rm -rf $@ $(notdir $@)
+	mkdir $(notdir $@)
+	cpu_family=riscv64; endian=little; \
+	case $(PICOLIBC_TUPLE) in riscv32*) cpu_family=riscv32 ;; esac; \
+	case $(PICOLIBC_TUPLE) in *be-*) endian=big ;; esac; \
+	cargs="'-msave-restore', '-fno-common'"; \
+	for f in $(CFLAGS_FOR_TARGET); do cargs="$$cargs, '$$f'"; done; \
+	tool=$(INSTALL_DIR)/bin/$(PICOLIBC_TUPLE); \
+	{ \
+	  echo "[binaries]"; \
+	  echo "c = ['$$tool-gcc', '-nostdlib']"; \
+	  echo "cpp = ['$$tool-g++', '-nostdlib']"; \
+	  echo "ar = '$$tool-ar'"; \
+	  echo "as = '$$tool-as'"; \
+	  echo "nm = '$$tool-nm'"; \
+	  echo "strip = '$$tool-strip'"; \
+	  echo "[host_machine]"; \
+	  echo "system = 'unknown'"; \
+	  echo "cpu_family = '$$cpu_family'"; \
+	  echo "cpu = '$$cpu_family'"; \
+	  echo "endian = '$$endian'"; \
+	  echo "[properties]"; \
+	  echo "c_args = [$$cargs]"; \
+	  echo "cpp_args = [$$cargs]"; \
+	  echo "skip_sanity_check = true"; \
+	} > $(notdir $@)/cross.txt
+	meson setup $(notdir $@) $(PICOLIBC_SRCDIR) \
+		--cross-file $(notdir $@)/cross.txt \
+		--buildtype=minsize \
+		--prefix=$(INSTALL_DIR)/$(PICOLIBC_TUPLE) \
+		-Dincludedir=include \
+		-Dlibdir=lib \
+		-Dsysroot-install=true \
+		-Dsystem-libc=true \
+		-Dtests=false \
+		$(PICOLIBC_TARGET_FLAGS)
+	ninja -C $(notdir $@) install
+	mkdir -p $(dir $@) && touch $@
+
+stamps/build-gcc-picolibc-stage2: ENABLED_LANGUAGES?="c,c++"
+stamps/build-gcc-picolibc-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-picolibc
+	rm -rf $@ $(notdir $@)
+	mkdir $(notdir $@)
+	cd $(notdir $@) && $</configure \
+		$(GCC_PICOLIBC_CONFIGURE_FLAGS) \
+		--enable-languages=$(ENABLED_LANGUAGES) \
+		--with-pkgversion="$(GCCPKGVER)" \
+		--with-native-system-header-dir=/include \
 		$(GCC_WITH_SPECS) \
 		$(GCC_EXTRA_CONFIGURE_FLAGS) \
 		CFLAGS_FOR_TARGET="-Os $(CFLAGS_FOR_TARGET)" \

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ RISC-V GNU Compiler Toolchain
 =============================
 
 This is the RISC-V C and C++ cross-compiler. It can build a bare-metal
-ELF toolchain (using Newlib) or a Linux-ELF toolchain (using glibc, musl,
-or uClibc).
+ELF toolchain (using Newlib or Picolibc) or a Linux-ELF toolchain
+(using glibc, musl, or uClibc).
 
 ###  Getting the sources
 
@@ -20,21 +20,21 @@ Several standard packages are needed to build the toolchain.
 
 On Ubuntu, executing the following command should suffice:
 
-    $ sudo apt-get install autoconf automake autotools-dev curl python3 python3-pip python3-tomli libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev expect device-tree-compiler libslirp-dev libzstd-dev libncurses-dev
+    $ sudo apt-get install autoconf automake autotools-dev curl python3 python3-pip python3-tomli libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev meson ninja-build git cmake libglib2.0-dev expect device-tree-compiler libslirp-dev libzstd-dev libncurses-dev
 
 On Fedora/CentOS/RHEL OS, executing the following command should suffice:
 
-    $ sudo yum install autoconf automake python3 libmpc-devel mpfr-devel gmp-devel gawk  bison flex texinfo patchutils gcc gcc-c++ zlib-devel expat-devel libslirp-devel ncurses-devel ninja-build cmake
+    $ sudo yum install autoconf automake python3 libmpc-devel mpfr-devel gmp-devel gawk  bison flex texinfo patchutils gcc gcc-c++ zlib-devel expat-devel libslirp-devel ncurses-devel meson ninja-build cmake
 
 On Arch Linux, executing the following command should suffice:
 
-    $ sudo pacman -Syu curl python3 libmpc mpfr gmp base-devel texinfo gperf patchutils bc zlib expat libslirp ncurses ninja cmake
+    $ sudo pacman -Syu curl python3 libmpc mpfr gmp base-devel texinfo gperf patchutils bc zlib expat libslirp ncurses meson ninja cmake
 
 Also available for Arch users on the AUR: [https://aur.archlinux.org/packages/riscv-gnu-toolchain-bin](https://aur.archlinux.org/packages/riscv-gnu-toolchain-bin)
 
 On macOS, you can use [Homebrew](http://brew.sh) to install the dependencies:
 
-    $ brew install python3 gawk gnu-sed make gmp mpfr libmpc isl zlib expat texinfo flock libslirp ncurses ninja cmake bison m4 wget
+    $ brew install python3 gawk gnu-sed make gmp mpfr libmpc isl zlib expat texinfo flock libslirp ncurses meson ninja cmake bison m4 wget
 
 When executing the instructions in this README, please use `gmake` instead of `make` to use the newly installed version of make.
 To build the glibc (Linux) on macOS, you will need to build within a case-sensitive file
@@ -56,21 +56,22 @@ Pick an install path that is writeable — say `/opt/riscv` — and add
 
 and build the C library you want:
 
-| C library      | build         |
-| -------------- | ------------- |
-| Newlib         | `make`        |
-| Linux (glibc)  | `make linux`  |
-| Linux (musl)   | `make musl`   |
-| Linux (uClibc) | `make uclibc` |
+| C library      | build           |
+| -------------- | --------------- |
+| Newlib         | `make`          |
+| Picolibc       | `make picolibc` |
+| Linux (glibc)  | `make linux`    |
+| Linux (musl)   | `make musl`     |
+| Linux (uClibc) | `make uclibc`   |
 
 You should now be able to use, e.g., `riscv64-unknown-elf-gcc` and its
-cousins.  The bare-metal (Newlib) tools are prefixed `riscv64-unknown-elf-`,
-the Linux tools `riscv64-unknown-linux-{gnu,musl,uclibc}-`.
+cousins.  The bare-metal (Newlib, Picolibc) tools are prefixed
+`riscv64-unknown-elf-`, the Linux tools `riscv64-unknown-linux-{gnu,musl,uclibc}-`.
 
 A plain `make` builds the default target, which is Newlib.  To make a
 different libc the default — so that `make` on its own builds it — configure
-with `--enable-newlib`, `--enable-linux`, `--enable-musl` or
-`--enable-uclibc`.
+with `--enable-newlib`, `--enable-linux`, `--enable-musl`, `--enable-uclibc`
+or `--enable-picolibc`.
 
 The build defaults to targeting RV64GC (64-bit), even on a 32-bit build
 environment.  To build a 32-bit toolchain, pass the arch and ABI, e.g.:
@@ -98,8 +99,8 @@ supports the most common `-march`/`-mabi` options, which can be seen with
 the `--print-multi-lib` flag.
 
 Multilib is only available for the Newlib and Linux/glibc toolchains; the
-musl and uClibc toolchains build a single variant, and configuring them
-with `--enable-multilib` is rejected.  Building them explicitly (e.g.
+musl, uClibc and Picolibc toolchains build a single variant, and configuring
+them with `--enable-multilib` is rejected.  Building them explicitly (e.g.
 `make musl`) in a tree configured for multilib still yields a single
 variant.
 
@@ -522,6 +523,7 @@ Here is the list of configure options for specifying alternative sources for the
     --with-llvm-src
     --with-musl-src
     --with-newlib-src
+    --with-picolibc-src
     --with-pk-src
     --with-qemu-src
     --with-spike-src

--- a/configure
+++ b/configure
@@ -627,6 +627,7 @@ with_gdb_src
 with_uclibc_src
 with_musl_src
 with_glibc_src
+with_picolibc_src
 with_newlib_src
 with_binutils_src
 with_gcc_src
@@ -722,6 +723,7 @@ enable_newlib
 enable_linux
 enable_musl
 enable_uclibc
+enable_picolibc
 enable_debug_info
 enable_default_pie
 with_arch
@@ -748,6 +750,7 @@ enable_strip
 with_gcc_src
 with_binutils_src
 with_newlib_src
+with_picolibc_src
 with_glibc_src
 with_musl_src
 with_uclibc_src
@@ -1395,6 +1398,8 @@ Optional Features:
                           [--disable-musl]
   --enable-uclibc         set uclibc as the default make target
                           [--disable-uclibc]
+  --enable-picolibc       set picolibc as the default make target
+                          [--disable-picolibc]
   --enable-debug-info     build glibc/musl/newlibc/libgcc with debug
                           information
   --enable-default-pie    build linux toolchain with default PIE
@@ -1423,8 +1428,8 @@ Optional Packages:
   --with-sim=qemu         Sets the base RISC-V Simulator, defaults to qemu
   --with-languages=       Sets the enabled languages for GNU toolchain,
                           defaults to c,c++,fortran for Linux/native and
-                          Linux/glibc or c,c++ for Bare-metal, Linux/musl and
-                          Linux/uClibc
+                          Linux/glibc or c,c++ for Bare-metal (Newlib and
+                          Picolibc), Linux/musl and Linux/uClibc
   --with-multilib-generator
                           Multi-libs configuration string, only supported for
                           bare-metal/elf toolchain, this option implied
@@ -1453,6 +1458,8 @@ Optional Packages:
   --with-binutils-src     Set binutils source path, use builtin source by
                           default
   --with-newlib-src       Set newlib source path, use builtin source by
+                          default
+  --with-picolibc-src     Set picolibc source path, use builtin source by
                           default
   --with-glibc-src        Set glibc source path, use builtin source by default
   --with-musl-src         Set musl source path, use builtin source by default
@@ -3969,6 +3976,13 @@ then :
 fi
 
 
+# Check whether --enable-picolibc was given.
+if test ${enable_picolibc+y}
+then :
+  enableval=$enable_picolibc;
+fi
+
+
 if test "x$enable_linux" = xyes
 then :
   default_target=linux
@@ -3984,6 +3998,11 @@ then :
   default_target=uclibc
 
 else $as_nop
+  if test "x$enable_picolibc" = xyes
+then :
+  default_target=picolibc
+
+else $as_nop
   if test "x$enable_newlib" = xyes
 then :
   default_target=newlib
@@ -3991,6 +4010,7 @@ then :
 else $as_nop
   default_target=newlib
 
+fi
 fi
 fi
 fi
@@ -4400,7 +4420,7 @@ fi
 if test "x$multilib_flags" = x--enable-multilib
 then :
   case $default_target in #(
-  musl | uclibc) :
+  musl | uclibc | picolibc) :
     as_fn_error $? "multilib is not supported for the $default_target toolchain" "$LINENO" 5 ;; #(
   *) :
      ;;
@@ -4412,7 +4432,7 @@ fi
 if test "x$enable_llvm" = x--enable-llvm
 then :
   case $default_target in #(
-  uclibc) :
+  uclibc | picolibc) :
     as_fn_error $? "LLVM is not supported for the $default_target toolchain" "$LINENO" 5 ;; #(
   *) :
      ;;
@@ -4518,6 +4538,27 @@ then :
 
 else $as_nop
   with_newlib_src="\$(srcdir)/newlib"
+
+fi
+
+	}
+{
+
+# Check whether --with-picolibc-src was given.
+if test ${with_picolibc_src+y}
+then :
+  withval=$with_picolibc_src;
+else $as_nop
+  with_picolibc_src=default
+
+fi
+
+	  if test "x$with_picolibc_src" != xdefault
+then :
+  with_picolibc_src=$with_picolibc_src
+
+else $as_nop
+  with_picolibc_src="\$(srcdir)/picolibc"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -56,12 +56,18 @@ AC_ARG_ENABLE(uclibc,
 	[AS_HELP_STRING([--enable-uclibc],
 		[set uclibc as the default make target @<:@--disable-uclibc@:>@])])
 
+AC_ARG_ENABLE(picolibc,
+	[AS_HELP_STRING([--enable-picolibc],
+		[set picolibc as the default make target @<:@--disable-picolibc@:>@])])
+
 AS_IF([test "x$enable_linux" = xyes],
 	[AC_SUBST(default_target, linux)],
 	[test "x$enable_musl" = xyes],
 	[AC_SUBST(default_target, musl)],
 	[test "x$enable_uclibc" = xyes],
 	[AC_SUBST(default_target, uclibc)],
+	[test "x$enable_picolibc" = xyes],
+	[AC_SUBST(default_target, picolibc)],
 	[test "x$enable_newlib" = xyes],
 	[AC_SUBST(default_target, newlib)],
 	[AC_SUBST(default_target, newlib)])
@@ -123,7 +129,7 @@ AC_ARG_WITH(sim,
 
 AC_ARG_WITH(languages,
 	[AS_HELP_STRING([--with-languages=],
-		[Sets the enabled languages for GNU toolchain, defaults to c,c++,fortran for Linux/native and Linux/glibc or c,c++ for Bare-metal, Linux/musl and Linux/uClibc])],
+		[Sets the enabled languages for GNU toolchain, defaults to c,c++,fortran for Linux/native and Linux/glibc or c,c++ for Bare-metal (Newlib and Picolibc), Linux/musl and Linux/uClibc])],
 	[]
 	) 
 
@@ -284,14 +290,14 @@ AS_IF([test "x$enable_llvm" = xyes],
 # available for them.  Reject it rather than silently ignoring the request.
 AS_IF([test "x$multilib_flags" = x--enable-multilib],
 	[AS_CASE([$default_target],
-		[musl | uclibc],
+		[musl | uclibc | picolibc],
 		[AC_MSG_ERROR([multilib is not supported for the $default_target toolchain])])])
 
 # There is no Clang runtime build for the uClibc toolchain, so --enable-llvm
 # would configure cleanly and then fail at make time.  Reject it up front.
 AS_IF([test "x$enable_llvm" = x--enable-llvm],
 	[AS_CASE([$default_target],
-		[uclibc],
+		[uclibc | picolibc],
 		[AC_MSG_ERROR([LLVM is not supported for the $default_target toolchain])])])
 
 AC_ARG_ENABLE(host-gcc,
@@ -329,6 +335,7 @@ AC_DEFUN([AX_ARG_WITH_SRC],
 AX_ARG_WITH_SRC(gcc, gcc)
 AX_ARG_WITH_SRC(binutils, binutils)
 AX_ARG_WITH_SRC(newlib, newlib)
+AX_ARG_WITH_SRC(picolibc, picolibc)
 AX_ARG_WITH_SRC(glibc, glibc)
 AX_ARG_WITH_SRC(musl, musl)
 AX_ARG_WITH_SRC(uclibc, uclibc-ng)


### PR DESCRIPTION
Add [Picolibc](https://github.com/picolibc/picolibc) as an additional
bare-metal C library alongside newlib. Picolibc support is upstream in GCC
since GCC 16, so no toolchain patches are needed.

This supersedes #1119, which required an out-of-tree GCC patch and stalled
waiting for upstream GCC. With that support now in GCC 16, this is a clean
reimplementation that needs no patches.

Built on top of #1885: the `--enable-picolibc` selection and the multilib/LLVM
guards reuse the default-libc-selection infrastructure added there.

## Commits

1. **Add Picolibc submodule**
   Tracked like the other C library submodules, cloned over https, `shallow`.

2. **Add Picolibc build support**
   `--enable-picolibc` makes it the default make target; it can also always be
   built with `make picolibc`.
   - Built with Meson and Ninja. The Meson cross file is small and fully
     derived from the target tuple, so it is generated inline in the build rule
     rather than tracked or emitted by a separate script.
   - The code model and other target flags are inherited from
     `CFLAGS_FOR_TARGET` (`--with-cmodel` and friends), so picolibc matches the
     rest of the toolchain instead of hardcoding its own.
   - Picolibc shares the `riscv*-unknown-elf` tuple with newlib, so its binutils
     and GDB are reused rather than rebuilt.
   - Single arch/ABI variant for now (no multilib); `--enable-multilib` and
     `--enable-llvm` are rejected for picolibc via the prep guards.
   - Meson is added to the dependency lists.

3. **CI: build Picolibc toolchains**
   Add picolibc to the default build matrix (`elf-picolibc` artifact name),
   with the LLVM compiler excluded (no Clang/picolibc integration yet).