### PR TITLE
docs(README): add missing Ubuntu prerequisites to match CI setup-apt.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Several standard packages are needed to build the toolchain.
 
 On Ubuntu, executing the following command should suffice:
 
-    $ sudo apt-get install autoconf automake autotools-dev curl python3 python3-pip python3-tomli libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev libncurses-dev
+    $ sudo apt-get install autoconf automake autotools-dev curl python3 python3-pip python3-tomli libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev expect device-tree-compiler libslirp-dev libzstd-dev libncurses-dev
 
 On Fedora/CentOS/RHEL OS, executing the following command should suffice:
 


### PR DESCRIPTION
The Ubuntu prerequisites in README.md are missing three packages that .github/setup-apt.sh installs for CI: `expect`, `device-tree-compiler` and `libzstd-dev`. This is the gap tracked in #1251.

This adds them to the Ubuntu `apt-get install` line so the documented prerequisites match what CI actually installs. `expect` is the runtime the DejaGnu test suite is built on; the other two are already in the CI script as well.

Per the maintainer's note in #1251 that additional dependencies are fine as long as they are also listed in the CI/CD script - all three are already in .github/setup-apt.sh. Scope is limited to the Ubuntu line, which is what CI covers and could be verified.

Closes #1251