### PR TITLE
Switch sourceware.org submodules to mirrors

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -116,9 +116,7 @@ jobs:
 
       - name: Checkout required submodules
         if: steps.smcache.outputs.cache-hit != 'true'
-        run: |
-          git submodule update --init dejagnu
-          git submodule update --init -j $(nproc) --depth 1 $(git submodule | awk '$2 != "dejagnu" {print $2}')
+        run: git submodule update --init -j $(nproc) --depth 1 $(git submodule | awk '{print $2}')
 
       - name: Storage size optimization
         if: steps.smcache.outputs.cache-hit != 'true'

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -116,7 +116,21 @@ jobs:
 
       - name: Checkout required submodules
         if: steps.smcache.outputs.cache-hit != 'true'
-        run: git submodule update --init -j $(nproc) --depth 1 $(git submodule | awk '{print $2}')
+        run: |
+          # git retries a failed clone once, roughly half a minute later, and
+          # then aborts the whole command. That is too short for a server-side
+          # error to clear, and it fails the job even when every other submodule
+          # cloned fine. Retry the update itself with a growing delay; it is
+          # resumable and skips submodules that are already checked out.
+          for i in 1 2 3 4 5; do
+            if git submodule update --init -j $(nproc) --depth 1 \
+                 $(git submodule | awk '{print $2}'); then
+              exit 0
+            fi
+            echo "submodule checkout failed (attempt ${i}), retrying in $((i * 30))s"
+            sleep $((i * 30))
+          done
+          exit 1
 
       - name: Storage size optimization
         if: steps.smcache.outputs.cache-hit != 'true'

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,7 +16,7 @@
 	path = dejagnu
 	url = https://git.savannah.gnu.org/git/dejagnu.git
 	branch = master
-	shallow = false
+	shallow = true
 [submodule "newlib"]
 	path = newlib
 	url = https://github.com/cygwin/cygwin.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "binutils"]
 	path = binutils
-	url = https://sourceware.org/git/binutils-gdb.git
+	url = https://github.com/gnutools/binutils-gdb.git
 	branch = binutils-2_46-branch
 	shallow = true
 [submodule "gcc"]
@@ -10,7 +10,7 @@
 	shallow = true
 [submodule "glibc"]
 	path = glibc
-	url = https://sourceware.org/git/glibc.git
+	url = https://github.com/gnutools/glibc.git
 	shallow = true
 [submodule "dejagnu"]
 	path = dejagnu
@@ -19,12 +19,12 @@
 	shallow = false
 [submodule "newlib"]
 	path = newlib
-	url = https://sourceware.org/git/newlib-cygwin.git
+	url = https://github.com/cygwin/cygwin.git
 	branch = master
 	shallow = true
 [submodule "gdb"]
 	path = gdb
-	url = https://sourceware.org/git/binutils-gdb.git
+	url = https://github.com/gnutools/binutils-gdb.git
 	branch = gdb-16-branch
 	shallow = true
 [submodule "qemu"]
@@ -33,7 +33,7 @@
 	shallow = true
 [submodule "musl"]
 	path = musl
-	url = https://git.musl-libc.org/git/musl
+	url = https://github.com/kraj/musl.git
 	branch = master
 	shallow = true
 [submodule "spike"]


### PR DESCRIPTION
Cloning the submodules hosted on sourceware.org (binutils, gdb, glibc, newlib) and
git.musl-libc.org (musl) fails frequently. The first answers HTTP 429/502 or times
out, the second stops answering at all.

Let's fix this issue by switching to the following mirrors:

| Submodule | Old URL | New URL |
|---|---|---|
| binutils | `sourceware.org/git/binutils-gdb.git` | `github.com/gnutools/binutils-gdb` |
| gdb | `sourceware.org/git/binutils-gdb.git` | `github.com/gnutools/binutils-gdb` |
| glibc | `sourceware.org/git/glibc.git` | `github.com/gnutools/glibc.git` |
| newlib | `sourceware.org/git/newlib-cygwin.git` | `github.com/cygwin/cygwin.git` |
| musl | `git.musl-libc.org/git/musl` | `github.com/kraj/musl` |

dejagnu stays on git.savannah.gnu.org: no mirror carries its pinned commit.

The second commit of this PR restores the shallow clone of dejagnu. Commit 68d10bc had to
disable it because git.savannah.gnu.org did not serve unadvertised objects. It does now,
so the workaround and its extra CI checkout step are no longer needed: the pin fetches
with --depth 1 into a single commit.

Commit 3 retries the submodule checkout. git retries a failed clone once, roughly half a
minute later, and then aborts the whole command, failing the job although every other
submodule cloned fine.