### PR TITLE
CI: split off LLVM build into its own job

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -223,7 +223,7 @@ jobs:
           ccache -z
           ccache -s
 
-      - name: build toolchain
+      - name: Configure toolchain
         run: |
           TARGET_TUPLE=($(echo ${{ matrix.target }} | tr "-" "\n"))
           BUILD_TOOLCHAIN="./configure --prefix=/mnt/riscv --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]}"
@@ -246,7 +246,10 @@ jobs:
           $BUILD_TOOLCHAIN $ARGS
           sudo mkdir /mnt/riscv
           sudo chown runner:runner /mnt/riscv
-          make -j $(nproc) ${{ matrix.mode }}
+
+      - name: Build toolchain
+        run: make -j $(nproc) ${{ matrix.mode }}
+
       - name: build simulator
         if: |
           matrix.build-sim == true

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -46,6 +46,13 @@ on:
         description: "Build simulator and include in the toolchain"
         type: boolean
         default: false
+      use-prebuilt-gnu:
+        description: >-
+          Do not build the GNU toolchain, take it from the artifact that the
+          gcc job of the same workflow run published, and build only LLVM on
+          top of it. Requires compiler '["llvm"]'.
+        type: boolean
+        default: false
 
 env:
   submodule_paths: |
@@ -88,6 +95,23 @@ jobs:
         run: |
           if [[ "${{ inputs.strip }}" != "unstripped" && "${{ inputs.strip }}" != "stripped" && "${{ inputs.strip }}" != "both" ]]; then
             echo "Invalid strip option: ${{ inputs.strip }}. Must be one of 'unstripped', 'stripped', 'both'."
+            exit 1
+          fi
+
+      - name: Check use-prebuilt-gnu input
+        if: ${{ inputs.use-prebuilt-gnu }}
+        run: |
+          # Only LLVM rows have a GNU toolchain to take from somewhere else. Any
+          # other row would download an artifact that does not exist and skip
+          # the build it is supposed to perform, so require exactly ["llvm"].
+          if [ "$(echo '${{ inputs.compiler }}' | tr -d '[]\" ')" != "llvm" ]; then
+            echo "use-prebuilt-gnu requires compiler '[\"llvm\"]', got ${{ inputs.compiler }}."
+            exit 1
+          fi
+          # The prebuilt path downloads the unstripped artifact, which is not
+          # published when only stripped tarballs are built.
+          if [[ "${{ inputs.strip }}" == "stripped" ]]; then
+            echo "use-prebuilt-gnu needs strip 'unstripped' or 'both', got 'stripped'."
             exit 1
           fi
 
@@ -168,6 +192,31 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: generate prebuilt toolchain name
+        id:   toolchain-name-generator
+        run: |
+          if [[ "${{ matrix.target }}" == *"32"* ]]; then BITS=32; else BITS=64; fi
+          case "${{ matrix.mode }}" in
+            "linux")
+              MODE="glibc";;
+            "musl")
+              MODE="musl";;
+            "uclibc")
+              MODE="uclibc-ng";;
+            *)
+              MODE="elf";;
+          esac
+          ARTIFACT_NAME=${{ inputs.artifact-name }}
+          if [ -n "$ARTIFACT_NAME" ]; then
+            ARTIFACT_NAME="-${ARTIFACT_NAME}"
+          fi
+          BASE_NAME="riscv$BITS-$MODE-${{ matrix.os }}-${{ matrix.compiler }}"
+          echo "TOOLCHAIN_NAME=${BASE_NAME}${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
+          echo "TOOLCHAIN_NAME_STRIPPED=${BASE_NAME}-stripped${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
+          # Same name, but for the gcc build of this row: what the prebuilt
+          # GNU toolchain is published as.
+          echo "GNU_NAME=riscv$BITS-$MODE-${{ matrix.os }}-gcc${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
+
       - name: Remove unneeded frameworks to recover disk space
         run: sudo ./.github/cleanup-rootfs.sh
 
@@ -223,6 +272,13 @@ jobs:
           ccache -z
           ccache -s
 
+      - name: Download prebuilt GNU toolchain
+        if: ${{ inputs.use-prebuilt-gnu }}
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ steps.toolchain-name-generator.outputs.GNU_NAME }}
+          path: prebuilt-gnu
+
       - name: Configure toolchain
         run: |
           TARGET_TUPLE=($(echo ${{ matrix.target }} | tr "-" "\n"))
@@ -247,8 +303,34 @@ jobs:
           sudo mkdir /mnt/riscv
           sudo chown runner:runner /mnt/riscv
 
+      - name: Restore prebuilt GNU toolchain
+        if: ${{ inputs.use-prebuilt-gnu }}
+        run: |
+          tar xJf prebuilt-gnu/${{ steps.toolchain-name-generator.outputs.GNU_NAME }}.tar.xz -C /mnt/
+          rm -rf prebuilt-gnu
+          # Fail here rather than somewhere inside the LLVM configure.
+          ls /mnt/riscv/bin/*-gcc >/dev/null 2>&1 || {
+            echo "error: the restored artifact contains no cross gcc in /mnt/riscv/bin"
+            exit 1
+          }
+
       - name: Build toolchain
+        if: ${{ !inputs.use-prebuilt-gnu }}
         run: make -j $(nproc) ${{ matrix.mode }}
+
+      # Build the LLVM stamp directly instead of the "<mode>" aggregate, so that
+      # this does not have to track whatever else "<mode>" pulls in. The only
+      # prerequisite of stamps/build-llvm-<mode> that the artifact restored above
+      # already provides is the stage2 stamp; "-o" marks it up to date without
+      # remaking it. This deliberately short-circuits the dependency graph and is
+      # only valid because the artifact comes from the gcc job of this same
+      # workflow run, built from the same commit.
+      - name: Build LLVM on the prebuilt GNU toolchain
+        if: ${{ inputs.use-prebuilt-gnu }}
+        run: |
+          make -j $(nproc) \
+            -o stamps/build-gcc-${{ matrix.mode }}-stage2 \
+            stamps/build-llvm-${{ matrix.mode }}
 
       - name: build simulator
         if: |
@@ -282,27 +364,6 @@ jobs:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-v1-${{ matrix.os }}-${{ github.run_id }}
 
-      - name: generate prebuilt toolchain name
-        id:   toolchain-name-generator
-        run: |
-          if [[ "${{ matrix.target }}" == *"32"* ]]; then BITS=32; else BITS=64; fi
-          case "${{ matrix.mode }}" in
-            "linux")
-              MODE="glibc";;
-            "musl")
-              MODE="musl";;
-            "uclibc")
-              MODE="uclibc-ng";;
-            *)
-              MODE="elf";;
-          esac
-          ARTIFACT_NAME=${{ inputs.artifact-name }}
-          if [ -n "$ARTIFACT_NAME" ]; then
-            ARTIFACT_NAME="-${ARTIFACT_NAME}"
-          fi
-          BASE_NAME="riscv$BITS-$MODE-${{ matrix.os }}-${{ matrix.compiler }}"
-          echo "TOOLCHAIN_NAME=${BASE_NAME}${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
-          echo "TOOLCHAIN_NAME_STRIPPED=${BASE_NAME}-stripped${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
       - name: Remove build trees before packaging
         run: |
           rm -rf build-* stamps install-host-gcc install-newlib-nano

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -350,6 +350,10 @@ jobs:
         if: always()
         run: ccache -s
 
+      # One job per OS writes the cache, and it is a GNU one. A second namespace
+      # for the LLVM half would not fit: CCACHE_MAXSIZE is 2G, so two namespaces
+      # for two OS versions are 8G, and together with the ~1.7G submodule cache
+      # that exceeds GitHub's 10G per repository.
       - name: Save ccache
         if: |
           always()
@@ -357,7 +361,7 @@ jobs:
           && github.event_name != 'pull_request'
           && matrix.mode == 'linux'
           && matrix.target == 'rv64gc-lp64d'
-          && matrix.compiler == 'llvm'
+          && matrix.compiler == 'gcc'
           && matrix.sim == ''
         uses: actions/cache/save@v5
         with:

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -328,7 +328,11 @@ jobs:
       - name: Build LLVM on the prebuilt GNU toolchain
         if: ${{ inputs.use-prebuilt-gnu }}
         run: |
+          # The ubuntu-22.04 rv64 rows keep losing their runner here. Some Flang
+          # sources need a lot of memory to compile, so limit how many of them
+          # are compiled at once on that OS.
           make -j $(nproc) \
+            FLANG_PARALLEL_COMPILE_JOBS=${{ matrix.os == 'ubuntu-22.04' && 2 || '' }} \
             -o stamps/build-gcc-${{ matrix.mode }}-stage2 \
             stamps/build-llvm-${{ matrix.mode }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,11 +10,32 @@ on:
       - master
 
 jobs:
+  # The GNU and LLVM builds run as separate jobs. An --enable-llvm build builds
+  # the complete GNU toolchain first and only then LLVM on top of it, which put
+  # the rv64 LLVM rows at or over the 6h job limit. Splitting them gives each
+  # half its own limit; the LLVM job takes the GNU toolchain from the artifact
+  # of the gcc job instead of building it again.
+  #
+  # Every LLVM row waits for the slowest gcc row, because "needs" cannot express
+  # a dependency between individual matrix entries of two reusable workflows.
+  # That costs wall-clock time but no job runs any longer than before.
   build:
     uses: ./.github/workflows/build-reusable.yaml
     with:
       artifact-name: build
+      compiler: '["gcc"]'
 
+  build-llvm:
+    needs: [build]
+    uses: ./.github/workflows/build-reusable.yaml
+    with:
+      artifact-name: build
+      compiler: '["llvm"]'
+      use-prebuilt-gnu: true
+
+  # Not split: this builds newlib only, which does not build flang, and its LLVM
+  # row takes about 200 minutes cold -- far enough from the job limit that the
+  # extra job and artifact round-trip would not buy anything.
   test-sim:
     uses: ./.github/workflows/build-reusable.yaml
     with:

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -55,9 +55,19 @@ jobs:
     needs: [activity-check]
     if: needs.activity-check.outputs.stale != 'true'
     uses: ./.github/workflows/build-reusable.yaml
+    with:
+      compiler: '["gcc"]'
+
+  # Builds LLVM on top of the GNU toolchain produced above, see build.yaml.
+  build-llvm:
+    needs: [build]
+    uses: ./.github/workflows/build-reusable.yaml
+    with:
+      compiler: '["llvm"]'
+      use-prebuilt-gnu: true
 
   create-release:
-    needs: [build]
+    needs: [build, build-llvm]
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/Makefile.in
+++ b/Makefile.in
@@ -20,6 +20,9 @@ LLVM_GENERATOR ?= Ninja
 # and pass it to ninja; else ninja uses all cores. Unix Makefiles gets -jN from
 # the `+` recipe lines below, so it must not get -jN here.
 LLVM_PARALLEL_JOBS ?= $(patsubst -j%,%,$(filter -j%,$(MAKEFLAGS)))
+# Concurrent link jobs in the LLVM builds (Ninja only). Links are the memory
+# peak of an LLVM build, so lower this where they exhaust the available RAM.
+LLVM_PARALLEL_LINK_JOBS ?= 4
 ifeq ($(LLVM_GENERATOR),Ninja)
 LLVM_BUILD_TOOL = ninja $(if $(LLVM_PARALLEL_JOBS),-j$(LLVM_PARALLEL_JOBS)) -C
 else
@@ -35,7 +38,7 @@ LLVM_LINUX_COMMON_CMAKE_FLAGS = \
     -DDEFAULT_SYSROOT="../sysroot" \
     -DLLVM_INSTALL_TOOLCHAIN_ONLY=On \
     -DLLVM_BINUTILS_INCDIR=$(BINUTILS_SRCDIR)/include \
-    -DLLVM_PARALLEL_LINK_JOBS=4
+    -DLLVM_PARALLEL_LINK_JOBS=$(LLVM_PARALLEL_LINK_JOBS)
 define LLVM_BUILD_OPENMP
 	if test $(XLEN) -eq 64; then \
 	    mkdir $(notdir $@)/openmp-shared; \
@@ -1326,7 +1329,7 @@ stamps/build-llvm-newlib: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BI
 	    -DLLVM_DEFAULT_TARGET_TRIPLE="$(NEWLIB_TUPLE)" \
 	    -DLLVM_INSTALL_TOOLCHAIN_ONLY=On \
 	    -DLLVM_BINUTILS_INCDIR=$(BINUTILS_SRCDIR)/include \
-	    -DLLVM_PARALLEL_LINK_JOBS=4 \
+	    -DLLVM_PARALLEL_LINK_JOBS=$(LLVM_PARALLEL_LINK_JOBS) \
 	    $(LLVM_EXTRA_CONFIGURE_FLAGS)
 	+$(LLVM_BUILD_TOOL) $(notdir $@)
 	+$(LLVM_BUILD_TOOL) $(notdir $@) $(subst -,/,$(INSTALL_TARGET))

--- a/Makefile.in
+++ b/Makefile.in
@@ -23,6 +23,10 @@ LLVM_PARALLEL_JOBS ?= $(patsubst -j%,%,$(filter -j%,$(MAKEFLAGS)))
 # Concurrent link jobs in the LLVM builds (Ninja only). Links are the memory
 # peak of an LLVM build, so lower this where they exhaust the available RAM.
 LLVM_PARALLEL_LINK_JOBS ?= 4
+# Concurrent Flang compile jobs (Ninja only). Some Flang sources need a lot of
+# memory to compile. Empty is the LLVM default and means no extra limit, so
+# these compiles are bounded by the -j of the build like every other job.
+FLANG_PARALLEL_COMPILE_JOBS ?=
 ifeq ($(LLVM_GENERATOR),Ninja)
 LLVM_BUILD_TOOL = ninja $(if $(LLVM_PARALLEL_JOBS),-j$(LLVM_PARALLEL_JOBS)) -C
 else
@@ -38,7 +42,8 @@ LLVM_LINUX_COMMON_CMAKE_FLAGS = \
     -DDEFAULT_SYSROOT="../sysroot" \
     -DLLVM_INSTALL_TOOLCHAIN_ONLY=On \
     -DLLVM_BINUTILS_INCDIR=$(BINUTILS_SRCDIR)/include \
-    -DLLVM_PARALLEL_LINK_JOBS=$(LLVM_PARALLEL_LINK_JOBS)
+    -DLLVM_PARALLEL_LINK_JOBS=$(LLVM_PARALLEL_LINK_JOBS) \
+    -DFLANG_PARALLEL_COMPILE_JOBS=$(FLANG_PARALLEL_COMPILE_JOBS)
 define LLVM_BUILD_OPENMP
 	if test $(XLEN) -eq 64; then \
 	    mkdir $(notdir $@)/openmp-shared; \


### PR DESCRIPTION
An `--enable-llvm` build builds the complete GNU toolchain first and only then
LLVM on top of it: `stamps/build-llvm-<mode>` depends on
`stamps/build-gcc-<mode>-stage2`. Every LLVM matrix row repeats what its gcc
sibling already built, in the same job and against the same 6h job limit.

Without a warm ccache we no longer fit. In the recent runs the rv64 LLVM rows
took 282 and 327 minutes where they passed and were killed at 360 minutes where
they did not, while their gcc siblings needed 46-72 minutes for the GNU half.

Therefore, this PR changes the following:
* `build` builds the GNU toolchains and publishes them as before.
* `build-llvm` unpacks the matching artifact into the install prefix and builds
  only LLVM, so each half gets its own job limit.

The published artifact is the install prefix, so nothing new is produced for
this. The LLVM job asks for `stamps/build-llvm-<mode>` directly and marks the
stage2 stamp up to date with `make -o`. That short-circuits the dependency
graph, and is only valid because the artifact comes from the gcc job of the same
run and the same commit; `--enable-llvm` is referenced exactly once in
`Makefile.in` and only adds the `stamps/build-llvm-*` targets.