### PR TITLE
ci: Apply Flang compile job limit to all OS versions

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -334,9 +334,10 @@ jobs:
         if: ${{ inputs.use-prebuilt-gnu }}
         run: |
           # Some Flang sources need a lot of memory to compile, so limit how many
-          # of them are compiled at once.
+          # of them are compiled at once, proportional to the runner's CPU count.
+          FLANG_PARALLEL_COMPILE_JOBS=$(( ($(nproc) + 1) / 2 ))
           make -j $(nproc) \
-            FLANG_PARALLEL_COMPILE_JOBS=2 \
+            FLANG_PARALLEL_COMPILE_JOBS=$FLANG_PARALLEL_COMPILE_JOBS \
             -o stamps/build-gcc-${{ matrix.mode }}-stage2 \
             stamps/build-llvm-${{ matrix.mode }}
 

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -333,11 +333,10 @@ jobs:
       - name: Build LLVM on the prebuilt GNU toolchain
         if: ${{ inputs.use-prebuilt-gnu }}
         run: |
-          # The ubuntu-22.04 rv64 rows keep losing their runner here. Some Flang
-          # sources need a lot of memory to compile, so limit how many of them
-          # are compiled at once on that OS.
+          # Some Flang sources need a lot of memory to compile, so limit how many
+          # of them are compiled at once.
           make -j $(nproc) \
-            FLANG_PARALLEL_COMPILE_JOBS=${{ matrix.os == 'ubuntu-22.04' && 2 || '' }} \
+            FLANG_PARALLEL_COMPILE_JOBS=2 \
             -o stamps/build-gcc-${{ matrix.mode }}-stage2 \
             stamps/build-llvm-${{ matrix.mode }}
 


### PR DESCRIPTION
The measurements in #1892 show that limiting FLANG_PARALLEL_COMPILE_JOBS to 2 speeds up the build by preventing memory pressure. Apply it to all OS versions instead of only ubuntu-22.04.